### PR TITLE
feat: basic payment channel settlement strategies

### DIFF
--- a/filecoin/filecoin.go
+++ b/filecoin/filecoin.go
@@ -27,6 +27,7 @@ type API interface {
 	StateDealProviderCollateralBounds(context.Context, abi.PaddedPieceSize, bool, TipSetKey) (DealCollateralBounds, error)
 	StateMinerInfo(context.Context, address.Address, TipSetKey) (MinerInfo, error)
 	StateMinerProvingDeadline(context.Context, address.Address, TipSetKey) (*dline.Info, error)
+	StateCall(context.Context, *Message, TipSetKey) (*InvocResult, error)
 	ChainReadObj(context.Context, cid.Cid) ([]byte, error)
 	ChainGetMessage(context.Context, cid.Cid) (*Message, error)
 	Close()

--- a/filecoin/lotus.go
+++ b/filecoin/lotus.go
@@ -28,6 +28,7 @@ type LotusAPI struct {
 		StateDealProviderCollateralBounds func(context.Context, abi.PaddedPieceSize, bool, TipSetKey) (DealCollateralBounds, error)
 		StateMinerInfo                    func(context.Context, address.Address, TipSetKey) (MinerInfo, error)
 		StateMinerProvingDeadline         func(context.Context, address.Address, TipSetKey) (*dline.Info, error)
+		StateCall                         func(context.Context, *Message, TipSetKey) (*InvocResult, error)
 		ChainReadObj                      func(context.Context, cid.Cid) ([]byte, error)
 		ChainGetMessage                   func(context.Context, cid.Cid) (*Message, error)
 	}
@@ -101,6 +102,10 @@ func (a *LotusAPI) StateMinerInfo(ctx context.Context, addr address.Address, tsk
 
 func (a *LotusAPI) StateMinerProvingDeadline(ctx context.Context, addr address.Address, tsk TipSetKey) (*dline.Info, error) {
 	return a.Methods.StateMinerProvingDeadline(ctx, addr, tsk)
+}
+
+func (a *LotusAPI) StateCall(ctx context.Context, msg *Message, tsk TipSetKey) (*InvocResult, error) {
+	return a.Methods.StateCall(ctx, msg, tsk)
 }
 
 func (a *LotusAPI) ChainReadObj(ctx context.Context, c cid.Cid) ([]byte, error) {

--- a/filecoin/testutils.go
+++ b/filecoin/testutils.go
@@ -13,13 +13,14 @@ import (
 
 // MockLotusAPI is for testing purposes only
 type MockLotusAPI struct {
-	act        *Actor               // actor to return when calling StateGetActor
-	actState   *ActorState          // state returned when calling StateReadState
-	obj        []byte               // bytes returned when calling ChainReadObj
-	objReader  func(cid.Cid) []byte // bytes to return given a specific cid
-	msgLookup  chan *MsgLookup      // msgLookup to return when calling StateWaitMsg
-	accountKey address.Address      // address returned when calling StateAccountKey
-	lookupID   address.Address      // address returned when calling StateLookupID
+	act         *Actor               // actor to return when calling StateGetActor
+	actState    *ActorState          // state returned when calling StateReadState
+	obj         []byte               // bytes returned when calling ChainReadObj
+	objReader   func(cid.Cid) []byte // bytes to return given a specific cid
+	msgLookup   chan *MsgLookup      // msgLookup to return when calling StateWaitMsg
+	accountKey  address.Address      // address returned when calling StateAccountKey
+	lookupID    address.Address      // address returned when calling StateLookupID
+	invocResult *InvocResult         // invocResult returned when calling StateCall
 }
 
 func NewMockLotusAPI() *MockLotusAPI {
@@ -84,6 +85,10 @@ func (m *MockLotusAPI) StateMinerProvingDeadline(ctx context.Context, addr addre
 	return nil, nil
 }
 
+func (m *MockLotusAPI) StateCall(ctx context.Context, msg *Message, tsk TipSetKey) (*InvocResult, error) {
+	return m.invocResult, nil
+}
+
 func (m *MockLotusAPI) ChainGetMessage(ctx context.Context, c cid.Cid) (*Message, error) {
 	return nil, nil
 }
@@ -126,4 +131,8 @@ func (m *MockLotusAPI) SetAccountKey(addr address.Address) {
 // SetMsgLookup to release the StateWaitMsg request
 func (m *MockLotusAPI) SetMsgLookup(lkp *MsgLookup) {
 	m.msgLookup <- lkp
+}
+
+func (m *MockLotusAPI) SetInvocResult(i *InvocResult) {
+	m.invocResult = i
 }

--- a/payments/manager.go
+++ b/payments/manager.go
@@ -2,10 +2,14 @@ package payments
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin/paych"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -24,6 +28,8 @@ type Manager interface {
 	AllocateLane(context.Context, address.Address) (uint64, error)
 	AddVoucherInbound(context.Context, address.Address, *paych.SignedVoucher, []byte, filecoin.BigInt) (filecoin.BigInt, error)
 	ChannelAvailableFunds(address.Address) (*AvailableFunds, error)
+	Settle(context.Context, address.Address) error
+	StartAutoCollect(context.Context) error
 }
 
 // Payments is our full payment system, it manages payment channels,
@@ -37,6 +43,9 @@ type Payments struct {
 
 	lk       sync.RWMutex
 	channels map[string]*channel
+
+	stopmu sync.Mutex
+	stop   chan struct{}
 }
 
 // New creates a new instance of payments manager
@@ -168,6 +177,183 @@ func (p *Payments) AddVoucherInbound(ctx context.Context, chAddr address.Address
 	ch.lk.Lock()
 	defer ch.lk.Unlock()
 	return ch.addVoucherUnlocked(ctx, chAddr, sv, minDelta)
+}
+
+// Settle a given channel and submits relevant vouchers then return the successfully submitted voucher
+func (p *Payments) Settle(ctx context.Context, addr address.Address) error {
+	ch, err := p.channelByAddress(addr)
+	if err != nil {
+		return err
+	}
+	var redeemedVch []*paych.SignedVoucher
+	best, err := p.bestSpendableByLane(ctx, addr)
+	if err != nil {
+		return err
+	}
+	if len(best) == 0 {
+		// If we have no vouchers to redeem it's probably not worth settling
+		return errors.New("no vouchers to redeem")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(best) + 1)
+
+	// We send our settle message at the same time as our voucher update messages
+	// hopefully they get on chain at the same time
+	mcid, err := ch.settle(ctx, addr)
+	if err != nil {
+		return err
+	}
+	// cancelling the context will timeout the wait function and all our goroutines will return
+	go func(sc cid.Cid) {
+		defer wg.Done()
+		lookup, err := p.api.StateWaitMsg(ctx, sc, uint64(5))
+		if err != nil {
+			fmt.Printf("settling payment channel %s failed: %v\n", addr, err)
+		}
+		if lookup.Receipt.ExitCode != 0 {
+			fmt.Printf("payment channel %s execution failed with code: %d\n", addr, lookup.Receipt.ExitCode)
+		}
+	}(mcid)
+
+	// I think all lanes should be merged so we might only get a single message but just in case
+	// we iterate over all the vouchers
+	for _, voucher := range best {
+		mcid, err := ch.submitVoucher(ctx, addr, voucher, nil)
+		if err != nil {
+			fmt.Printf("unable to submit voucher: %v\n", err)
+			continue
+		}
+		go func(vouch *paych.SignedVoucher, mcid cid.Cid) {
+			defer wg.Done()
+			lookup, err := p.api.StateWaitMsg(ctx, mcid, uint64(5))
+			if err != nil {
+				fmt.Printf("waiting for voucher to submit on channel %s: %v\n", addr, err)
+			}
+			if lookup.Receipt.ExitCode != 0 {
+				fmt.Printf("voucher update execution failed for channel %s with code %d\n", addr, lookup.Receipt.ExitCode)
+			}
+			redeemedVch = append(redeemedVch, vouch)
+		}(voucher, mcid)
+	}
+	go func() {
+		// Wait to settle and send the last vouchers then we save the collection epoch
+		wg.Wait()
+		state, err := ch.loadActorState(addr)
+		if err != nil {
+			fmt.Printf("loading actor state: %v\n", err)
+			return
+		}
+		ci, err := p.store.ByAddress(addr)
+		if err != nil {
+			return
+		}
+		ep, err := state.SettlingAt()
+		if err != nil {
+			return
+		}
+		p.store.SetChannelSettlingAt(ci, ep)
+	}()
+	return nil
+}
+
+// StartAutoCollect is a routine that ticks every epoch and tries to collect settling payment channels
+// called usually at startup
+func (p *Payments) StartAutoCollect(ctx context.Context) error {
+	if p.api == nil {
+		return nil
+	}
+	// TODO: we may want to load all channel info into memory to avoid reading from the store every 30s
+	go p.collectLoop(ctx)
+	return nil
+}
+
+// collectLoop is the collection routine
+func (p *Payments) collectLoop(ctx context.Context) {
+	p.stopmu.Lock()
+	if p.stop != nil {
+		return // already running
+	}
+	p.stop = make(chan struct{})
+	p.stopmu.Unlock()
+
+	head, err := p.api.ChainHead(ctx)
+	if err != nil {
+		return
+	}
+	epoch := head.Height()
+	for {
+		select {
+		case <-time.Tick(builtin.EpochDurationSeconds * time.Second):
+			epoch++
+			p.collectForEpoch(ctx, epoch)
+
+			// We've prob lost sync with the clock so let's query again just in case
+			head, err := p.api.ChainHead(ctx)
+			// no need to fail the whole routine if the request fails once in a while
+			if err != nil {
+				continue
+			}
+			epoch = head.Height()
+
+		case <-ctx.Done():
+			return
+		case <-p.stop:
+			return
+		}
+	}
+}
+
+// collectForEpoch tries to collect any channel matching with the epoch
+func (p *Payments) collectForEpoch(ctx context.Context, epoch abi.ChainEpoch) error {
+	settling, err := p.store.ListSettlingChannels()
+	if err != nil || len(settling) == 0 {
+		return err
+	}
+	for _, sci := range settling {
+		if sci.SettlingAt >= epoch {
+			// Using ByFromTo to avoid another store read
+			ch, err := p.channelByFromTo(sci.Control, sci.Target)
+			if err != nil {
+				return err
+			}
+			mcid, err := ch.collect(ctx, *sci.Channel)
+			if err != nil {
+				return err
+			}
+			lookup, err := p.api.StateWaitMsg(ctx, mcid, uint64(5))
+			if err != nil {
+				fmt.Printf("waiting to collect channel %s: %v\n", sci.Channel, err)
+			}
+			if lookup.Receipt.ExitCode != 0 {
+				fmt.Printf("collecting channel %s failed with code %d\n", sci.Channel, lookup.Receipt.ExitCode)
+			}
+			if lookup.Receipt.ExitCode == 0 {
+				ch.mutateChannelInfo(sci.ChannelID, func(ci *ChannelInfo) {
+					ci.Settling = false
+				})
+			}
+
+		}
+	}
+	return nil
+}
+
+// bestSpendableByLane only returns the merged vouchers for each lane
+func (p *Payments) bestSpendableByLane(ctx context.Context, ch address.Address) (map[uint64]*paych.SignedVoucher, error) {
+	vouchers, err := p.ListVouchers(ctx, ch)
+	if err != nil {
+		return nil, err
+	}
+
+	bestByLane := make(map[uint64]*paych.SignedVoucher)
+	for _, vi := range vouchers {
+		// TODO: spendable, err := PaychVoucherCheckSpendable(ctx, ch, voucher, nil, nil)
+		if bestByLane[vi.Voucher.Lane] == nil || vi.Voucher.Amount.GreaterThan(bestByLane[vi.Voucher.Lane].Amount) {
+			bestByLane[vi.Voucher.Lane] = vi.Voucher
+		}
+	}
+	return bestByLane, nil
 }
 
 // inboundChannel gets an accessor for the given channel. The channel

--- a/payments/manager_test.go
+++ b/payments/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/v3/actors/builtin"
@@ -123,7 +124,7 @@ func TestAddFunds(t *testing.T) {
 
 // TestPaychAddVoucherAfterAddFunds tests adding a voucher to a channel with
 // insufficient funds, then adding funds to the channel, then adding the
-// voucher again
+// voucher again. It is happening on the payer side
 func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 	bgCtx := context.Background()
 
@@ -249,4 +250,322 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 	vouchRes, err = mgr.CreateVoucher(ctx, chAddr, excessAmt, 2)
 	require.NoError(t, err)
 	require.NotNil(t, vouchRes.Voucher)
+}
+
+// TestBestSpendable is on the payee side to test the process of receiving and storing vouchers
+// then verifying which vouchers to submit
+func TestBestSpendable(t *testing.T) {
+	bgCtx := context.Background()
+
+	ctx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
+	defer cancel()
+
+	api := fil.NewMockLotusAPI()
+
+	ks := keystore.NewMemKeystore()
+
+	w := wallet.NewIPFS(ks, api)
+
+	from, err := w.NewKey(ctx, wallet.KTSecp256k1)
+	require.NoError(t, err)
+
+	payerAddr := tutils.NewIDAddr(t, 102)
+	payeeAddr := tutils.NewIDAddr(t, 103)
+
+	ds := dssync.MutexWrap(ds.NewMapDatastore())
+	cborstore := cbor.NewCborStore(&mockBlocks{make(map[cid.Cid]block.Block)})
+
+	mgr := New(bgCtx, api, w, ds, cborstore)
+
+	createAmt := big.NewInt(20)
+	act := &fil.Actor{
+		Code:    blockGen.Next().Cid(),
+		Head:    blockGen.Next().Cid(),
+		Nonce:   0,
+		Balance: createAmt,
+	}
+	api.SetActor(act)
+	chAddr := tutils.NewIDAddr(t, 101)
+
+	initActorAddr := tutils.NewIDAddr(t, 100)
+	hasher := func(data []byte) [32]byte { return [32]byte{} }
+
+	builder := mock.NewBuilder(ctx, chAddr).
+		WithBalance(createAmt, abi.NewTokenAmount(0)).
+		WithEpoch(abi.ChainEpoch(1)).
+		WithCaller(initActorAddr, builtin.InitActorCodeID).
+		WithActorType(payeeAddr, builtin.AccountActorCodeID).
+		WithActorType(payerAddr, builtin.AccountActorCodeID).
+		WithHasher(hasher)
+
+	// builder our actor runtime
+	rt := builder.Build(t)
+	params := &paych.ConstructorParams{To: payeeAddr, From: payerAddr}
+	rt.ExpectValidateCallerType(builtin.InitActorCodeID)
+	actor := paych.Actor{}
+	rt.Call(actor.Constructor, params)
+
+	var st paych.State
+	rt.GetState(&st)
+
+	actState := fil.ActorState{
+		Balance: createAmt,
+		State:   st,
+	}
+	// add our actor state to the api so it's queryable
+	api.SetActorState(&actState)
+	// object reader to send a serialized object
+	objReader := func(c cid.Cid) []byte {
+		var bg bytesGetter
+		rt.StoreGet(c, &bg)
+		return bg.Bytes()
+	}
+	api.SetObjectReader(objReader)
+
+	api.SetAccountKey(from)
+
+	// Add vouchers to lane 1 with amounts: [1, 2, 3]
+	voucherLane := uint64(1)
+	minDelta := big.NewInt(0)
+	nonce := uint64(1)
+	voucherAmount := big.NewInt(1)
+	svL1V1 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL1V1, nil, minDelta)
+	require.NoError(t, err)
+
+	nonce++
+	voucherAmount = big.NewInt(2)
+	svL1V2 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL1V2, nil, minDelta)
+	require.NoError(t, err)
+
+	nonce++
+	voucherAmount = big.NewInt(3)
+	svL1V3 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL1V3, nil, minDelta)
+	require.NoError(t, err)
+
+	// Add voucher to lane 2 with amounts: [2]
+	voucherLane = uint64(2)
+	nonce = uint64(1)
+	voucherAmount = big.NewInt(2)
+	svL2V1 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL2V1, nil, minDelta)
+	require.NoError(t, err)
+
+	// Return success exit code from calls to check if voucher is spendable
+	api.SetInvocResult(&fil.InvocResult{
+		MsgRct: &fil.MessageReceipt{
+			ExitCode: 0,
+		},
+	})
+
+	// Verify best spendable vouchers on each lane
+	vouchers, err := mgr.bestSpendableByLane(ctx, chAddr)
+	require.NoError(t, err)
+	require.Len(t, vouchers, 2)
+
+	vchr, ok := vouchers[1]
+	require.True(t, ok)
+	require.EqualValues(t, 3, vchr.Amount.Int64())
+
+	vchr, ok = vouchers[2]
+	require.True(t, ok)
+	require.EqualValues(t, 2, vchr.Amount.Int64())
+
+	// Submit voucher from lane 2
+	_, err = mgr.SubmitVoucher(ctx, chAddr, svL2V1, nil, nil)
+	require.NoError(t, err)
+
+	// Best spendable voucher should no longer include lane 2
+	// (because voucher has not been submitted)
+	vouchers, err = mgr.bestSpendableByLane(ctx, chAddr)
+	require.NoError(t, err)
+	require.Len(t, vouchers, 1)
+
+	// Submit first voucher from lane 1
+	_, err = mgr.SubmitVoucher(ctx, chAddr, svL1V1, nil, nil)
+	require.NoError(t, err)
+
+	// Best spendable voucher for lane 1 should still be highest value voucher
+	vouchers, err = mgr.bestSpendableByLane(ctx, chAddr)
+	require.NoError(t, err)
+	require.Len(t, vouchers, 1)
+
+	vchr, ok = vouchers[1]
+	require.True(t, ok)
+	require.EqualValues(t, 3, vchr.Amount.Int64())
+}
+
+// TestCollectChannel is on the payee side once we've received all the vouchers
+// we should be able to settle the channel and submit all the vouchers then collect it
+func TestCollectChannel(t *testing.T) {
+	bgCtx := context.Background()
+
+	ctx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
+	defer cancel()
+
+	api := fil.NewMockLotusAPI()
+
+	ks := keystore.NewMemKeystore()
+
+	w := wallet.NewIPFS(ks, api)
+
+	from, err := w.NewKey(ctx, wallet.KTSecp256k1)
+	require.NoError(t, err)
+
+	payerAddr := tutils.NewIDAddr(t, 102)
+	payeeAddr := tutils.NewIDAddr(t, 103)
+
+	ds := dssync.MutexWrap(ds.NewMapDatastore())
+	cborstore := cbor.NewCborStore(&mockBlocks{make(map[cid.Cid]block.Block)})
+
+	mgr := New(bgCtx, api, w, ds, cborstore)
+
+	createAmt := big.NewInt(20)
+	act := &fil.Actor{
+		Code:    blockGen.Next().Cid(),
+		Head:    blockGen.Next().Cid(),
+		Nonce:   0,
+		Balance: createAmt,
+	}
+	api.SetActor(act)
+	chAddr := tutils.NewIDAddr(t, 101)
+
+	initActorAddr := tutils.NewIDAddr(t, 100)
+	hasher := func(data []byte) [32]byte { return [32]byte{} }
+
+	builder := mock.NewBuilder(ctx, chAddr).
+		WithBalance(createAmt, abi.NewTokenAmount(0)).
+		WithEpoch(abi.ChainEpoch(1)).
+		WithCaller(initActorAddr, builtin.InitActorCodeID).
+		WithActorType(payeeAddr, builtin.AccountActorCodeID).
+		WithActorType(payerAddr, builtin.AccountActorCodeID).
+		WithHasher(hasher)
+
+	// builder our actor runtime
+	rt := builder.Build(t)
+	params := &paych.ConstructorParams{To: payeeAddr, From: payerAddr}
+	rt.ExpectValidateCallerType(builtin.InitActorCodeID)
+	actor := paych.Actor{}
+	rt.Call(actor.Constructor, params)
+
+	var st paych.State
+	rt.GetState(&st)
+
+	actState := fil.ActorState{
+		Balance: createAmt,
+		State:   st,
+	}
+	// add our actor state to the api so it's queryable
+	api.SetActorState(&actState)
+	// object reader to send a serialized object
+	objReader := func(c cid.Cid) []byte {
+		var bg bytesGetter
+		rt.StoreGet(c, &bg)
+		return bg.Bytes()
+	}
+	api.SetObjectReader(objReader)
+
+	api.SetAccountKey(from)
+
+	// Add vouchers to lane 1 with amounts: [1, 2, 3]
+	voucherLane := uint64(1)
+	minDelta := big.NewInt(0)
+	nonce := uint64(1)
+	voucherAmount := big.NewInt(1)
+	svL1V1 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL1V1, nil, minDelta)
+	require.NoError(t, err)
+
+	nonce++
+	voucherAmount = big.NewInt(2)
+	svL1V2 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL1V2, nil, minDelta)
+	require.NoError(t, err)
+
+	nonce++
+	voucherAmount = big.NewInt(3)
+	svL1V3 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL1V3, nil, minDelta)
+	require.NoError(t, err)
+
+	// Add voucher to lane 2 with amounts: [2]
+	voucherLane = uint64(2)
+	nonce = uint64(1)
+	voucherAmount = big.NewInt(2)
+	svL2V1 := createTestVoucher(t, chAddr, voucherLane, nonce, voucherAmount, from, w)
+	_, err = mgr.AddVoucherInbound(ctx, chAddr, svL2V1, nil, minDelta)
+	require.NoError(t, err)
+
+	// Return success exit code from calls to check if voucher is spendable
+	api.SetInvocResult(&fil.InvocResult{
+		MsgRct: &fil.MessageReceipt{
+			ExitCode: 0,
+		},
+	})
+
+	err = mgr.Settle(ctx, chAddr)
+	require.NoError(t, err)
+
+	ep := abi.ChainEpoch(10)
+	rt.SetEpoch(ep)
+
+	rt.GetState(&st)
+	rt.SetCaller(st.From, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerAddr(st.From, st.To)
+	rt.Call(actor.Settle, nil)
+
+	rt.GetState(&st)
+	actState = fil.ActorState{
+		Balance: createAmt,
+		State:   st,
+	}
+	// update our actor state to the api so it's queryable
+	api.SetActorState(&actState)
+
+	lookup := formatMsgLookup(t, chAddr)
+	// We should have 3 chain txs we're waiting for
+	for i := 0; i < 3; i++ {
+		api.SetMsgLookup(lookup)
+	}
+	// Now we should have 1 settling channel
+	settling, err := mgr.store.ListSettlingChannels()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(settling))
+
+	rt.GetState(&st)
+
+	done := make(chan struct{})
+	go func() {
+		err = mgr.collectForEpoch(ctx, st.SettlingAt+1)
+		require.NoError(t, err)
+		close(done)
+	}()
+
+	// confirm collect message
+	api.SetMsgLookup(lookup)
+
+	<-done
+
+	// Now we should have no settling channels
+	settling, err = mgr.store.ListSettlingChannels()
+	require.NoError(t, err)
+	require.Equal(t, 0, len(settling))
+}
+
+func createTestVoucher(t *testing.T, ch address.Address, voucherLane uint64, nonce uint64, voucherAmount big.Int, addr address.Address, w wallet.Driver) *paych.SignedVoucher {
+	sv := &paych.SignedVoucher{
+		ChannelAddr: ch,
+		Lane:        voucherLane,
+		Nonce:       nonce,
+		Amount:      voucherAmount,
+	}
+
+	signingBytes, err := sv.SigningBytes()
+	require.NoError(t, err)
+	sig, err := w.Sign(context.TODO(), addr, signingBytes)
+	require.NoError(t, err)
+	sv.Signature = sig
+	return sv
 }

--- a/retrieval/deal/types.go
+++ b/retrieval/deal/types.go
@@ -199,7 +199,6 @@ type ClientState struct {
 	UnsealFundsPaid      abi.TokenAmount
 	WaitMsgCID           *cid.Cid // the CID of any message the client deal is waiting for
 	VoucherShortfall     abi.TokenAmount
-	LegacyProtocol       bool
 }
 
 // ProviderState is the current state of a deal from the point of view
@@ -215,7 +214,9 @@ type ProviderState struct {
 	FundsReceived   abi.TokenAmount
 	Message         string
 	CurrentInterval uint64
-	LegacyProtocol  bool
+	// Added PayCh field so we can get the reference to the payment channel
+	// in fsm event subscriber
+	PayCh *address.Address
 }
 
 // Identifier provides a unique id for this provider deal

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -99,6 +99,14 @@ func (p *mockPayments) SetChannelAvailableFunds(funds payments.AvailableFunds) {
 	p.chFunds = &chFunds
 }
 
+func (p *mockPayments) Settle(ctx context.Context, addr address.Address) error {
+	return nil
+}
+
+func (p *mockPayments) StartAutoCollect(ctx context.Context) error {
+	return nil
+}
+
 type mockStoreIDGetter struct {
 	id  multistore.StoreID
 	err error

--- a/retrieval/validators.go
+++ b/retrieval/validators.go
@@ -270,7 +270,7 @@ func (pr *ProviderRevalidator) processPayment(dealID deal.ProviderDealIdentifier
 
 	// check if all payments are received to continue the deal, or send updated required payment
 	if received.LessThan(paymentOwed) {
-		_ = pr.env.SendEvent(dealID, provider.EventPartialPaymentReceived, received)
+		_ = pr.env.SendEvent(dealID, provider.EventPartialPaymentReceived, received, payment.PaymentChannel)
 		return &deal.Response{
 			ID:          d.ID,
 			Status:      d.Status,
@@ -279,7 +279,7 @@ func (pr *ProviderRevalidator) processPayment(dealID deal.ProviderDealIdentifier
 	}
 
 	// resume deal
-	_ = pr.env.SendEvent(dealID, provider.EventPaymentReceived, received)
+	_ = pr.env.SendEvent(dealID, provider.EventPaymentReceived, received, payment.PaymentChannel)
 	if d.Status == deal.StatusFundsNeededLastPayment {
 		return &deal.Response{
 			ID:     d.ID,


### PR DESCRIPTION
This is a very naive approach to payment channel settlement and collection in which:
- We settle after any terminated transfer if we have collected any voucher. If settlement is successful we mark them as settling.
- We iterate through every settling channel at every epoch to check if any is ready to collect. 

Caveats:
- Currently iterate through every stored channel info to find settling channels then iterate again through every settling channel to find any with matching epoch which can get expensive if there are many channels
- We use a local ticker to follow new epochs and may become out of sync with the network epoch if we don't refetch every now and then