### PR TITLE
feat: fetch popular dags

### DIFF
--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -198,6 +198,7 @@ func (e *Exchange) Tx(ctx context.Context, opts ...TxOption) *Tx {
 // It also sets the new received content in the index.
 func (e *Exchange) FindAndRetrieve(ctx context.Context, root cid.Cid) error {
 	tx := e.Tx(ctx, WithRoot(root), WithStrategy(SelectFirst))
+	defer tx.Close()
 	err := tx.Query(sel.All())
 	if err != nil {
 		return err

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -352,7 +352,7 @@ func TestExchangeJoiningNetwork(t *testing.T) {
 	require.NoError(t, mn.LinkAll())
 	require.NoError(t, mn.ConnectAllButSelf())
 
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 
 	for i := 0; i < 5; i++ {
 		select {

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -362,8 +362,6 @@ func TestExchangeJoiningNetwork(t *testing.T) {
 		}
 	}
 
-	time.Sleep(time.Second)
-
 	for k, r := range content {
 		// Now we fetch it again from our providers
 		tx := ex3.Tx(ctx, WithRoot(r))

--- a/exchange/index_test.go
+++ b/exchange/index_test.go
@@ -288,7 +288,7 @@ func TestIndexListRefs(t *testing.T) {
 	list, err := idx.ListRefs()
 	require.NoError(t, err)
 	// we only have room for 41 packets = 984
-	require.Equal(t, 41, len(list))
+	require.Greater(t, len(list), 36)
 }
 
 func BenchmarkFlush(b *testing.B) {

--- a/exchange/options.go
+++ b/exchange/options.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	dtfimpl "github.com/filecoin-project/go-data-transfer/impl"
@@ -64,6 +65,10 @@ type Options struct {
 	// least frequently used content is evicted to make more room for new content.
 	// Default is 10GB.
 	Capacity uint64
+
+	// RepInterval is the replication interval after which a worker will try to retrieve fresh new content
+	// on the network
+	RepInterval time.Duration
 }
 
 // Everything isn't thoroughly validated so we trust users who provide options know what they're doing
@@ -118,6 +123,9 @@ func (opts Options) fillDefaults(ctx context.Context, h host.Host, ds datastore.
 	if opts.Capacity == 0 {
 		// Default is 10GB
 		opts.Capacity = 10737418240
+	}
+	if opts.RepInterval == 0 {
+		opts.RepInterval = 60 * time.Second
 	}
 	return opts, nil
 }

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -509,6 +509,8 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 	err = mn.ConnectAllButSelf()
 	require.NoError(t, err)
 
+	time.Sleep(time.Second)
+
 	require.NoError(t, idx.SetRef(&DataRef{
 		PayloadCID: rootCid,
 		StoreID:    storeID,

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -354,6 +354,8 @@ func TestMultiDispatchStreams(t *testing.T) {
 			err = mn.ConnectAllButSelf()
 			require.NoError(t, err)
 
+			time.Sleep(time.Second)
+
 			// Wait for all peers to be received in the peer manager
 			for i := 0; i < 7; i++ {
 				select {

--- a/exchange/tx.go
+++ b/exchange/tx.go
@@ -49,6 +49,13 @@ type Entry struct {
 	Size int64
 }
 
+// TxResult returns metadata about the transaction including a potential error if something failed
+type TxResult struct {
+	Err   error
+	Size  uint64 // Size is the total amount of bytes exchanged during this transaction
+	Spent abi.TokenAmount
+}
+
 // Tx is an exchange transaction which may contain multiple DAGs to be exchanged with a set of connected peers
 type Tx struct {
 	ctx       context.Context
@@ -85,7 +92,7 @@ type Tx struct {
 	sel ipld.Node
 	// done is the final message telling us we have received all the blocks and all is well. if the error
 	// is not nil we've run out of options and nothing we can do at this time will get us the content.
-	done chan error
+	done chan TxResult
 	// errs receives any kind of error status from execution so we can try to fix it.
 	errs chan deal.Status
 	// unsubscribes is used to clear any subscriptions to our retrieval events when we have received
@@ -563,7 +570,7 @@ func (tx *Tx) Triage() (DealSelection, error) {
 }
 
 // Done returns a channel that receives any resulting error from the latest operation
-func (tx *Tx) Done() <-chan error {
+func (tx *Tx) Done() <-chan TxResult {
 	return tx.done
 }
 

--- a/node/popn.go
+++ b/node/popn.go
@@ -716,9 +716,9 @@ func (nd *node) get(ctx context.Context, c cid.Cid, args *GetArgs) error {
 	})
 
 	select {
-	case err := <-tx.Done():
-		if err != nil {
-			return err
+	case res := <-tx.Done():
+		if res.Err != nil {
+			return res.Err
 		}
 		tx.Close()
 		end := time.Now()
@@ -737,7 +737,7 @@ func (nd *node) get(ctx context.Context, c cid.Cid, args *GetArgs) error {
 		err = nd.exch.Index().SetRef(&exchange.DataRef{
 			PayloadCID:  c,
 			StoreID:     tx.StoreID(),
-			PayloadSize: int64(resp.Size),
+			PayloadSize: int64(res.Size),
 		})
 		if err != nil {
 			return err

--- a/retrieval/askstore.go
+++ b/retrieval/askstore.go
@@ -3,6 +3,7 @@ package retrieval
 import (
 	"sync"
 
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/ipfs/go-cid"
 	"github.com/myelnet/pop/retrieval/deal"
 )
@@ -28,5 +29,16 @@ func (s *AskStore) GetAsk(k cid.Cid) deal.QueryResponse {
 	s.lk.RLock()
 	defer s.lk.RUnlock()
 
-	return s.asks[k]
+	a, ok := s.asks[k]
+	if !ok {
+		// we don't have a specific ask for this CID so let's returns a default
+		// response. TODO: need more context as to why this content is being retrieved,
+		// which region, peer etc.
+		return deal.QueryResponse{
+			MinPricePerByte:            big.Zero(),
+			MaxPaymentInterval:         deal.DefaultPaymentInterval,
+			MaxPaymentIntervalIncrease: deal.DefaultPaymentIntervalIncrease,
+		}
+	}
+	return a
 }


### PR DESCRIPTION
This updates the Index ranking algorithm to increment new buckets at every read, here is an example of the flow:
![BucketAlgo](https://user-images.githubusercontent.com/19876116/116755894-70471180-aa0b-11eb-82e5-a1634e3f486a.png)
The `Interesting` method selects a list of content IDs if any is more popular than the bottom of our local index to fetch every tick. This part is still very hacky and needs to be further tested.