### PR TITLE
add build when running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: install
+all: build install
 
 FFI_PATH:=./extern/filecoin-ffi/
 FFI_DEPS:=.install-filcrypto


### PR DESCRIPTION
Running ```make``` alone did not work for me, I had to first run ```make build```.
We can add build in the ```all: ```target, or change the Readme to precise to run the ```make build```before ?