### PR TITLE
feat: set replication interval to 0 to deactivate replication job

### DIFF
--- a/cmd/pop/cli/start.go
+++ b/cmd/pop/cli/start.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/docker/go-units"
@@ -23,10 +24,11 @@ import (
 
 // PopConfig is the json config object we generate with the init command
 type PopConfig struct {
-	temp        bool
-	privKeyPath string
-	regions     string
-	capacity    string
+	temp         bool
+	privKeyPath  string
+	regions      string
+	capacity     string
+	replInterval time.Duration
 	// Exported fields can be set by survey.Ask
 	Bootstrap    string `json:"bootstrap"`
 	FilEndpoint  string `json:"fil-endpoint"`
@@ -55,6 +57,7 @@ The 'pop start' command starts a pop daemon service.
 		fs.StringVar(&startArgs.privKeyPath, "privkey", "", "path to private key to use by default")
 		fs.StringVar(&startArgs.regions, "regions", "", "provider regions separated by commas")
 		fs.StringVar(&startArgs.capacity, "capacity", "10GB", "storage space allocated for the node")
+		fs.DurationVar(&startArgs.replInterval, "replinterval", 0, "at which interval to check for new content from peers. 0 means the feature is deactivated")
 
 		return fs
 	})(),
@@ -154,6 +157,7 @@ Manage your Myel point of presence from the command line.
 		PrivKey:        privKey,
 		Regions:        regions,
 		Capacity:       capacity,
+		ReplInterval:   startArgs.replInterval,
 	}
 
 	err = node.Run(ctx, opts)

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -69,8 +69,7 @@ func New(ctx context.Context, h host.Host, ds datastore.Batching, opts Options) 
 		rou:  NewGossipRouting(h, opts.PubSub, opts.GossipTracer, opts.Regions),
 		w:    wallet.NewFromKeystore(opts.Keystore, opts.FilecoinAPI),
 	}
-	exch.rpl = NewReplication(h, idx, opts.DataTransfer, exch, opts.Regions)
-	exch.rpl.interval = opts.RepInterval
+	exch.rpl = NewReplication(h, idx, opts.DataTransfer, exch, opts)
 	// Make a new default key to be sure we have an address where to receive our payments
 	if exch.w.DefaultAddress() == address.Undef {
 		_, err = exch.w.NewKey(ctx, wallet.KTSecp256k1)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -339,11 +339,11 @@ func TestExchangeJoiningNetwork(t *testing.T) {
 			newNode := func() (*Exchange, *testutil.TestNode) {
 				n := testutil.NewTestNode(mn, t)
 				opts := Options{
-					Blockstore:  n.Bs,
-					MultiStore:  n.Ms,
-					RepoPath:    n.DTTmpDir,
-					Keystore:    keystore.NewMemKeystore(),
-					RepInterval: 2 * time.Second,
+					Blockstore:   n.Bs,
+					MultiStore:   n.Ms,
+					RepoPath:     n.DTTmpDir,
+					Keystore:     keystore.NewMemKeystore(),
+					ReplInterval: 2 * time.Second,
 				}
 				exch, err := New(bgCtx, n.Host, n.Ds, opts)
 				require.NoError(t, err)

--- a/exchange/options.go
+++ b/exchange/options.go
@@ -66,9 +66,9 @@ type Options struct {
 	// Default is 10GB.
 	Capacity uint64
 
-	// RepInterval is the replication interval after which a worker will try to retrieve fresh new content
+	// ReplInterval is the replication interval after which a worker will try to retrieve fresh new content
 	// on the network
-	RepInterval time.Duration
+	ReplInterval time.Duration
 }
 
 // Everything isn't thoroughly validated so we trust users who provide options know what they're doing
@@ -124,8 +124,8 @@ func (opts Options) fillDefaults(ctx context.Context, h host.Host, ds datastore.
 		// Default is 10GB
 		opts.Capacity = 10737418240
 	}
-	if opts.RepInterval == 0 {
-		opts.RepInterval = 60 * time.Second
+	if opts.ReplInterval == 0 {
+		opts.ReplInterval = 60 * time.Second
 	}
 	return opts, nil
 }

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -126,9 +126,8 @@ func TestReplication(t *testing.T) {
 			idx,
 			n.Dt,
 			rtv,
-			[]Region{global},
+			Options{Regions: []Region{global}, ReplInterval: 2 * time.Second},
 		)
-		repl.interval = 2 * time.Second
 		require.NoError(t, repl.Start(ctx))
 		return n, repl, rtv
 	}
@@ -339,9 +338,8 @@ func TestConcurrentReplication(t *testing.T) {
 					idx,
 					n.Dt,
 					rtv,
-					[]Region{global},
+					Options{Regions: []Region{global}, ReplInterval: 3 * time.Second},
 				)
-				repl.interval = 3 * time.Second
 				require.NoError(t, repl.Start(ctx))
 				return n, repl, rtv
 			}
@@ -451,10 +449,11 @@ func TestMultiDispatchStreams(t *testing.T) {
 					Code: CustomRegion,
 				},
 			}
+			opts := Options{Regions: regions}
 
 			idx, err := NewIndex(n1.Ds, n1.Ms)
 			require.NoError(t, err)
-			hn := NewReplication(n1.Host, idx, n1.Dt, NewMockRetriever(n1.Dt, idx), regions)
+			hn := NewReplication(n1.Host, idx, n1.Dt, NewMockRetriever(n1.Dt, idx), opts)
 			require.NoError(t, idx.SetRef(&DataRef{
 				PayloadCID: rootCid,
 				StoreID:    storeID,
@@ -475,7 +474,7 @@ func TestMultiDispatchStreams(t *testing.T) {
 				})
 				idx, err := NewIndex(tnode.Ds, tnode.Ms)
 				require.NoError(t, err)
-				hn1 := NewReplication(tnode.Host, idx, tnode.Dt, NewMockRetriever(tnode.Dt, idx), regions)
+				hn1 := NewReplication(tnode.Host, idx, tnode.Dt, NewMockRetriever(tnode.Dt, idx), opts)
 				require.NoError(t, hn1.Start(ctx))
 				receivers[tnode.Host.ID()] = hn1
 				tnds[tnode.Host.ID()] = tnode
@@ -538,10 +537,11 @@ func TestSendDispatchNoPeers(t *testing.T) {
 			Code: CustomRegion,
 		},
 	}
+	opts := Options{Regions: regions}
 
 	idx, err := NewIndex(n1.Ds, n1.Ms)
 	require.NoError(t, err)
-	supply := NewReplication(n1.Host, idx, n1.Dt, NewMockRetriever(n1.Dt, idx), regions)
+	supply := NewReplication(n1.Host, idx, n1.Dt, NewMockRetriever(n1.Dt, idx), opts)
 	require.NoError(t, idx.SetRef(&DataRef{
 		PayloadCID: rootCid,
 		StoreID:    storeID,
@@ -586,7 +586,7 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 
 	idx, err := NewIndex(n1.Ds, n1.Ms)
 	require.NoError(t, err)
-	supply := NewReplication(n1.Host, idx, n1.Dt, NewMockRetriever(n1.Dt, idx), asia)
+	supply := NewReplication(n1.Host, idx, n1.Dt, NewMockRetriever(n1.Dt, idx), Options{Regions: asia})
 	sub, err := n1.Host.EventBus().Subscribe(new(HeyEvt), eventbus.BufSize(16))
 	require.NoError(t, err)
 	require.NoError(t, supply.Start(ctx))
@@ -604,7 +604,7 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 
 		idx, err := NewIndex(n.Ds, n.Ms)
 		require.NoError(t, err)
-		s := NewReplication(n.Host, idx, n.Dt, NewMockRetriever(n1.Dt, idx), asia)
+		s := NewReplication(n.Host, idx, n.Dt, NewMockRetriever(n1.Dt, idx), Options{Regions: asia})
 		require.NoError(t, s.Start(ctx))
 
 		asiaNodes[n.Host.ID()] = n
@@ -629,7 +629,7 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 		idx, err := NewIndex(n.Ds, n.Ms)
 		require.NoError(t, err)
 
-		s := NewReplication(n.Host, idx, n.Dt, NewMockRetriever(n.Dt, idx), africa)
+		s := NewReplication(n.Host, idx, n.Dt, NewMockRetriever(n.Dt, idx), Options{Regions: africa})
 		require.NoError(t, s.Start(ctx))
 
 		africaNodes[n.Host.ID()] = n

--- a/node/popn.go
+++ b/node/popn.go
@@ -96,6 +96,8 @@ type Options struct {
 	Regions []string
 	// Capacity is the maxium storage capacity dedicated to the exchange
 	Capacity uint64
+	// ReplInterval defines how often the node attempts to find new content from connected peers
+	ReplInterval time.Duration
 }
 
 // RemoteStorer is the interface used to store content on decentralized storage networks (Filecoin)
@@ -200,8 +202,9 @@ func New(ctx context.Context, opts Options) (*node, error) {
 		FilecoinRPCHeader: http.Header{
 			"Authorization": []string{opts.FilToken},
 		},
-		Regions:  regions,
-		Capacity: opts.Capacity,
+		Regions:      regions,
+		Capacity:     opts.Capacity,
+		ReplInterval: opts.ReplInterval,
 	}
 
 	nd.exch, err = exchange.New(ctx, nd.host, nd.ds, eopts)


### PR DESCRIPTION
Allows setting the node replication interval in the start options. It is disabled by default as it is still unstable.