### PR TITLE
feat: single blockstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 testground/data
 dist/
 *DS_Store
+exchange.test
+node.test

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -132,7 +132,8 @@ func (e *Exchange) handleQuery(ctx context.Context, p peer.ID, r Region, q deal.
 	return resp, nil
 }
 
-// Tx returns a new transaction
+// Tx returns a new transaction. The caller must also call tx.Close to cleanup and perist the new blocks
+// retrieved or created by the transaction.
 func (e *Exchange) Tx(ctx context.Context, opts ...TxOption) *Tx {
 	// This cancel allows us to shutdown the retrieval process with the session if needed
 	ctx, cancel := context.WithCancel(ctx)
@@ -167,6 +168,7 @@ func (e *Exchange) Tx(ctx context.Context, opts ...TxOption) *Tx {
 	tx := &Tx{
 		ctx:        ctx,
 		cancelCtx:  cancel,
+		bs:         e.opts.Blockstore,
 		ms:         e.opts.MultiStore,
 		rou:        e.rou,
 		retriever:  cl,

--- a/exchange/index_cbor_gen.go
+++ b/exchange/index_cbor_gen.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"sort"
 
-	multistore "github.com/filecoin-project/go-multistore"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
@@ -22,7 +21,7 @@ func (t *DataRef) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{166}); err != nil {
+	if _, err := w.Write([]byte{165}); err != nil {
 		return err
 	}
 
@@ -64,22 +63,6 @@ func (t *DataRef) MarshalCBOR(w io.Writer) error {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajNegativeInt, uint64(-t.PayloadSize-1)); err != nil {
 			return err
 		}
-	}
-
-	// t.StoreID (multistore.StoreID) (uint64)
-	if len("StoreID") > cbg.MaxLength {
-		return xerrors.Errorf("Value in field \"StoreID\" was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("StoreID"))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string("StoreID")); err != nil {
-		return err
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.StoreID)); err != nil {
-		return err
 	}
 
 	// t.Keys ([][]uint8) (slice)
@@ -232,21 +215,6 @@ func (t *DataRef) UnmarshalCBOR(r io.Reader) error {
 				}
 
 				t.PayloadSize = int64(extraI)
-			}
-			// t.StoreID (multistore.StoreID) (uint64)
-		case "StoreID":
-
-			{
-
-				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-				if err != nil {
-					return err
-				}
-				if maj != cbg.MajUnsignedInt {
-					return fmt.Errorf("wrong type for uint64 field")
-				}
-				t.StoreID = multistore.StoreID(extra)
-
 			}
 			// t.Keys ([][]uint8) (slice)
 		case "Keys":

--- a/exchange/index_test.go
+++ b/exchange/index_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/filecoin-project/go-multistore"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -27,10 +26,8 @@ var blockGen = blocksutil.NewBlockGenerator()
 
 func TestIndexLFU(t *testing.T) {
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	ms, err := multistore.NewMultiDstore(ds)
-	require.NoError(t, err)
 
-	idx, err := NewIndex(ds, ms, WithBounds(512000, 500000))
+	idx, err := NewIndex(ds, WithBounds(512000, 500000))
 
 	ref1 := &DataRef{
 		PayloadCID:  blockGen.Next().Cid(),
@@ -63,7 +60,7 @@ func TestIndexLFU(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test reinitializing the list from the stored frequencies
-	idx, err = NewIndex(ds, ms, WithBounds(512000, 500000))
+	idx, err = NewIndex(ds, WithBounds(512000, 500000))
 	require.NoError(t, err)
 
 	// Add another read to ref2
@@ -94,10 +91,8 @@ func TestIndexLFU(t *testing.T) {
 // This test verifies refs are moving correctly across buckets when incrementing reads and writes
 func TestIndexRanking(t *testing.T) {
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	ms, err := multistore.NewMultiDstore(ds)
-	require.NoError(t, err)
 
-	idx, err := NewIndex(ds, ms, WithBounds(512000, 500000))
+	idx, err := NewIndex(ds, WithBounds(512000, 500000))
 
 	write := func() *DataRef {
 		ref := &DataRef{
@@ -245,10 +240,8 @@ func TestIndexRanking(t *testing.T) {
 
 func TestIndexDropRef(t *testing.T) {
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	ms, err := multistore.NewMultiDstore(ds)
-	require.NoError(t, err)
 
-	idx, err := NewIndex(ds, ms)
+	idx, err := NewIndex(ds)
 	require.NoError(t, err)
 
 	ref := &DataRef{
@@ -266,10 +259,8 @@ func TestIndexDropRef(t *testing.T) {
 
 func TestIndexListRefs(t *testing.T) {
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	ms, err := multistore.NewMultiDstore(ds)
-	require.NoError(t, err)
 
-	idx, err := NewIndex(ds, ms, WithBounds(1000, 900))
+	idx, err := NewIndex(ds, WithBounds(1000, 900))
 
 	var refs []*DataRef
 	// this loop sets 100 refs for 24 bytes = 2400 bytes
@@ -307,10 +298,9 @@ func TestIndexListRefs(t *testing.T) {
 func BenchmarkFlush(b *testing.B) {
 	b.Run("SetRef", func(b *testing.B) {
 		ds := dss.MutexWrap(datastore.NewMapDatastore())
-		ms, err := multistore.NewMultiDstore(ds)
-		require.NoError(b, err)
 
-		idx, err := NewIndex(ds, ms, WithBounds(1000, 900))
+		idx, err := NewIndex(ds, WithBounds(1000, 900))
+		require.NoError(b, err)
 
 		b.ReportAllocs()
 		runtime.GC()
@@ -320,7 +310,6 @@ func BenchmarkFlush(b *testing.B) {
 			require.NoError(b, idx.SetRef(&DataRef{
 				PayloadCID:  cid,
 				PayloadSize: 100000,
-				StoreID:     multistore.StoreID(1),
 				Freq:        3,
 			}))
 		}
@@ -330,10 +319,9 @@ func BenchmarkFlush(b *testing.B) {
 // This selector should query a HAMT without following the links
 func TestIndexSelector(t *testing.T) {
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	ms, err := multistore.NewMultiDstore(ds)
-	require.NoError(t, err)
 
-	idx, err := NewIndex(ds, ms)
+	idx, err := NewIndex(ds)
+	require.NoError(t, err)
 
 	lb := cidlink.LinkBuilder{
 		Prefix: cid.Prefix{
@@ -393,10 +381,8 @@ func TestIndexSelector(t *testing.T) {
 func TestIndexInterest(t *testing.T) {
 	newIndex := func(n int) *Index {
 		ds := dss.MutexWrap(datastore.NewMapDatastore())
-		ms, err := multistore.NewMultiDstore(ds)
-		require.NoError(t, err)
 
-		idx, err := NewIndex(ds, ms, WithBounds(1000, 900))
+		idx, err := NewIndex(ds, WithBounds(1000, 900))
 		require.NoError(t, err)
 
 		var refs []*DataRef
@@ -429,10 +415,8 @@ func TestIndexInterest(t *testing.T) {
 func TestLoadInterest(t *testing.T) {
 	newIndex := func() *Index {
 		ds := dss.MutexWrap(datastore.NewMapDatastore())
-		ms, err := multistore.NewMultiDstore(ds)
-		require.NoError(t, err)
 
-		idx, err := NewIndex(ds, ms, WithBounds(1000, 900))
+		idx, err := NewIndex(ds, WithBounds(1000, 900))
 		require.NoError(t, err)
 		return idx
 	}

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -625,7 +625,7 @@ func TransportConfigurer(idx *Index, isg IdxStoreGetter, pid peer.ID) datatransf
 		}
 		// When initiating both FetchIndex and Dispatch transfers we've already assigned a store
 		// with the root CID so we just need to get it
-		if request.Method == FetchIndex && channelID.Initiator == pid || request.Method == Dispatch {
+		if (request.Method == FetchIndex && channelID.Initiator == pid) || request.Method == Dispatch {
 			// When we're fetching a new index we store it in a new store
 			store := isg.GetStore(request.PayloadCID)
 			err := gsTransport.UseStore(channelID, store.Loader, store.Storer)

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/go-multistore"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync/storeutil"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/jpillora/backoff"
@@ -99,6 +100,8 @@ type RoutedRetriever interface {
 type Replication struct {
 	h         host.Host
 	dt        datatransfer.Manager
+	ms        *multistore.MultiStore
+	bs        blockstore.Blockstore
 	pm        *PeerMgr
 	hs        *HeyService
 	idx       *Index
@@ -126,6 +129,8 @@ func NewReplication(h host.Host, idx *Index, dt datatransfer.Manager, rtv Routed
 		rgs:       opts.Regions,
 		idx:       idx,
 		rtv:       rtv,
+		ms:        opts.MultiStore,
+		bs:        opts.Blockstore,
 		interval:  opts.ReplInterval,
 		reqProtos: []protocol.ID{PopRequestProtocolID},
 		pulls:     make(map[cid.Cid]*peer.Set),
@@ -252,13 +257,9 @@ func (r *Replication) fetchIndex(ctx context.Context, hvt HeyEvt) error {
 		PayloadCID: rcid,
 	}
 
-	store, err := r.idx.ms.Get(r.idx.ms.Next())
-	if err != nil {
+	if err := r.AddStore(rcid, r.ms.Next()); err != nil {
 		return err
 	}
-	r.smu.Lock()
-	r.stores[rcid] = store
-	r.smu.Unlock()
 
 	chid, err := r.dt.OpenPullDataChannel(ctx, hvt.Peer, &req, rcid, sel.Hamt())
 	if err != nil {
@@ -281,11 +282,30 @@ func (r *Replication) fetchIndex(ctx context.Context, hvt HeyEvt) error {
 	}
 }
 
+// AddStore assigns a store for a given root cid and store ID
+func (r *Replication) AddStore(k cid.Cid, sid multistore.StoreID) error {
+	store, err := r.ms.Get(sid)
+	if err != nil {
+		return err
+	}
+	r.smu.Lock()
+	r.stores[k] = store
+	r.smu.Unlock()
+	return nil
+}
+
 // GetStore returns the store used for a given root index
 func (r *Replication) GetStore(k cid.Cid) *multistore.Store {
 	r.smu.Lock()
 	defer r.smu.Unlock()
 	return r.stores[k]
+}
+
+// RmStore cleans up the store when it is not needed anymore
+func (r *Replication) RmStore(k cid.Cid) {
+	r.smu.Lock()
+	defer r.smu.Unlock()
+	delete(r.stores, k)
 }
 
 // balanceIndex checks if any content in the interest list is more popular than content in the supply
@@ -334,26 +354,20 @@ func (r *Replication) handleRequest(s network.Stream) {
 	switch req.Method {
 	case Dispatch:
 		// TODO: validate request
-		// Create a new store to receive our new blocks
-		// It will be automatically picked up in the TransportConfigurer
-		storeID := r.idx.ms.Next()
 
+		// Check if we may already have this content
 		_, err := r.idx.GetRef(req.PayloadCID)
 		if err == nil {
 			fmt.Printf("Payload CID %s already exists\n", req.PayloadCID.String())
 			return
 		}
 
-		ref := &DataRef{
-			PayloadCID:  req.PayloadCID,
-			PayloadSize: int64(req.Size),
-			StoreID:     storeID,
-			Keys:        [][]byte{},
-		}
-
-		err = r.idx.SetRef(ref)
-		if err != nil {
-			fmt.Println("error when setting ref before OpenPullDataChannel :", err)
+		// Create a new store to receive our new blocks
+		// It will be automatically picked up in the TransportConfigurer
+		sid := r.ms.Next()
+		if err := r.AddStore(req.PayloadCID, sid); err != nil {
+			fmt.Println("error when creating new store", err)
+			return
 		}
 
 		ctx := context.Background()
@@ -379,22 +393,27 @@ func (r *Replication) handleRequest(s network.Stream) {
 				return
 
 			case datatransfer.Completed:
-				store, err := r.idx.ms.Get(storeID)
-				if err != nil {
-					fmt.Println("error when fetching store :", err)
-					return
-				}
+				store := r.GetStore(req.PayloadCID)
 
-				keys, err := utils.MapKeys(ctx, ref.PayloadCID, store.Loader)
+				keys, err := utils.MapKeys(ctx, req.PayloadCID, store.Loader)
 				if err != nil {
 					fmt.Println("error when fetching keys :", err)
-					return
 				}
-				ref.Keys = keys.AsBytes()
 
-				err = r.idx.SetRef(ref)
-				if err != nil {
+				if err := r.idx.SetRef(&DataRef{
+					PayloadCID:  req.PayloadCID,
+					PayloadSize: int64(req.Size),
+					Keys:        keys.AsBytes(),
+				}); err != nil {
 					fmt.Println("error when setting ref :", err)
+				}
+
+				if err := utils.MigrateBlocks(ctx, store.Bstore, r.bs); err != nil {
+					fmt.Println("error migrating blocks :", err)
+				}
+
+				if err := r.ms.Delete(sid); err != nil {
+					fmt.Println("error deleting store :", err)
 				}
 				return
 			}
@@ -413,6 +432,7 @@ type DispatchOptions struct {
 	BackoffMin     time.Duration
 	BackoffAttemps int
 	RF             int
+	StoreID        multistore.StoreID
 }
 
 // DefaultDispatchOptions provides useful defaults
@@ -424,7 +444,11 @@ var DefaultDispatchOptions = DispatchOptions{
 }
 
 // Dispatch to the network until we have propagated the content to enough peers
-func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) chan PRecord {
+func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (chan PRecord, error) {
+	if err := r.AddStore(root, opt.StoreID); err != nil {
+		return nil, err
+	}
+
 	req := Request{
 		Method:     Dispatch,
 		PayloadCID: root,
@@ -451,6 +475,7 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) c
 		defer func() {
 			unsub()
 			close(out)
+
 		}()
 		// The peers we already sent requests to
 		rcv := make(map[peer.ID]bool)
@@ -501,7 +526,7 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) c
 			}
 		}
 	}()
-	return out
+	return out, nil
 }
 
 func (r *Replication) sendAllRequests(req Request, peers []peer.ID) {
@@ -598,7 +623,9 @@ func TransportConfigurer(idx *Index, isg IdxStoreGetter, pid peer.ID) datatransf
 		if !ok {
 			return
 		}
-		if request.Method == FetchIndex && channelID.Initiator == pid {
+		// When initiating both FetchIndex and Dispatch transfers we've already assigned a store
+		// with the root CID so we just need to get it
+		if request.Method == FetchIndex && channelID.Initiator == pid || request.Method == Dispatch {
 			// When we're fetching a new index we store it in a new store
 			store := isg.GetStore(request.PayloadCID)
 			err := gsTransport.UseStore(channelID, store.Loader, store.Storer)
@@ -607,6 +634,7 @@ func TransportConfigurer(idx *Index, isg IdxStoreGetter, pid peer.ID) datatransf
 			}
 			return
 		}
+		// Someone is retrieving our index, it should be loaded from the index's blockstore
 		if request.Method == FetchIndex {
 			loader := storeutil.LoaderForBlockstore(idx.Bstore())
 			storer := storeutil.StorerForBlockstore(idx.Bstore())
@@ -615,15 +643,6 @@ func TransportConfigurer(idx *Index, isg IdxStoreGetter, pid peer.ID) datatransf
 				warn(err)
 			}
 			return
-		}
-		store, err := idx.GetStore(request.PayloadCID)
-		if err != nil {
-			warn(err)
-			return
-		}
-		err = gsTransport.UseStore(channelID, store.Loader, store.Storer)
-		if err != nil {
-			warn(err)
 		}
 	}
 }

--- a/exchange/tx_test.go
+++ b/exchange/tx_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-multistore"
 	files "github.com/ipfs/go-ipfs-files"
 	keystore "github.com/ipfs/go-ipfs-keystore"
 	"github.com/ipfs/go-path"
@@ -27,80 +28,89 @@ func TestTx(t *testing.T) {
 	newNode := func(ctx context.Context, mn mocknet.Mocknet) (*Exchange, *testutil.TestNode) {
 		n := testutil.NewTestNode(mn, t)
 		opts := Options{
-			RepoPath: n.DTTmpDir,
-			Keystore: keystore.NewMemKeystore(),
+			RepoPath:     n.DTTmpDir,
+			Keystore:     keystore.NewMemKeystore(),
+			ReplInterval: -1,
 		}
 		exch, err := New(ctx, n.Host, n.Ds, opts)
 		require.NoError(t, err)
 		return exch, n
 	}
-	// Iterating a ton helps weed out false positives
-	for i := 0; i < 1; i++ {
-		t.Run(fmt.Sprintf("Try %v", i), func(t *testing.T) {
-			bgCtx := context.Background()
+	bgCtx := context.Background()
 
-			ctx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
-			defer cancel()
+	ctx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
+	defer cancel()
 
-			mn := mocknet.New(bgCtx)
+	mn := mocknet.New(bgCtx)
 
-			var providers []*Exchange
-			var pnodes []*testutil.TestNode
+	var providers []*Exchange
+	var pnodes []*testutil.TestNode
 
-			for i := 0; i < 11; i++ {
-				exch, n := newNode(ctx, mn)
-				providers = append(providers, exch)
-				pnodes = append(pnodes, n)
-			}
-			require.NoError(t, mn.LinkAll())
-			require.NoError(t, mn.ConnectAllButSelf())
-
-			// The peer manager has time to fill up while we load this file
-			fname := pnodes[0].CreateRandomFile(t, 56000)
-			tx := providers[0].Tx(ctx)
-			link, bytes := pnodes[0].LoadFileToStore(ctx, t, tx.Store(), fname)
-			rootCid := link.(cidlink.Link).Cid
-			require.NoError(t, tx.Put(KeyFromPath(fname), rootCid, int64(len(bytes))))
-
-			file, err := tx.GetFile(KeyFromPath(fname))
-			require.NoError(t, err)
-			size, err := file.Size()
-			require.NoError(t, err)
-			require.Equal(t, size, int64(56000))
-
-			// Commit the transaction will dipatch the content to the network
-			require.NoError(t, tx.Commit())
-
-			var records []PRecord
-			tx.WatchDispatch(func(rec PRecord) {
-				records = append(records, rec)
-			})
-			require.Equal(t, 6, len(records))
-			root := tx.Root()
-			tx.Close()
-
-			// Create a new client
-			client, _ := newNode(ctx, mn)
-
-			require.NoError(t, mn.LinkAll())
-			require.NoError(t, mn.ConnectAllButSelf())
-
-			tx = client.Tx(ctx, WithRoot(root), WithStrategy(SelectFirst))
-			require.NoError(t, tx.Query(sel.Key(KeyFromPath(fname))))
-			select {
-			case <-ctx.Done():
-				t.Fatal("tx timeout")
-			case <-tx.Done():
-			}
-			file, err = tx.GetFile(KeyFromPath(fname))
-			require.NoError(t, err)
-			size, err = file.Size()
-			require.NoError(t, err)
-			require.Equal(t, size, int64(56000))
-		})
+	for i := 0; i < 11; i++ {
+		exch, n := newNode(ctx, mn)
+		providers = append(providers, exch)
+		pnodes = append(pnodes, n)
 	}
+	require.NoError(t, mn.LinkAll())
+	require.NoError(t, mn.ConnectAllButSelf())
 
+	// The peer manager has time to fill up while we load this file
+	fname := pnodes[0].CreateRandomFile(t, 56000)
+	tx := providers[0].Tx(ctx)
+	link, bytes := pnodes[0].LoadFileToStore(ctx, t, tx.Store(), fname)
+	rootCid := link.(cidlink.Link).Cid
+	require.NoError(t, tx.Put(KeyFromPath(fname), rootCid, int64(len(bytes))))
+
+	file, err := tx.GetFile(KeyFromPath(fname))
+	require.NoError(t, err)
+	size, err := file.Size()
+	require.NoError(t, err)
+	require.Equal(t, size, int64(56000))
+
+	// Commit the transaction will dipatch the content to the network
+	require.NoError(t, tx.Commit())
+
+	var records []PRecord
+	tx.WatchDispatch(func(rec PRecord) {
+		records = append(records, rec)
+	})
+	require.Equal(t, 6, len(records))
+	root := tx.Root()
+	require.NoError(t, tx.Close())
+
+	// Create a new client
+	client, _ := newNode(ctx, mn)
+
+	require.NoError(t, mn.LinkAll())
+	require.NoError(t, mn.ConnectAllButSelf())
+
+	tx = client.Tx(ctx, WithRoot(root), WithStrategy(SelectFirst))
+	require.NoError(t, tx.Query(sel.Key(KeyFromPath(fname))))
+	select {
+	case <-ctx.Done():
+		t.Fatal("tx timeout")
+	case <-tx.Done():
+	}
+	file, err = tx.GetFile(KeyFromPath(fname))
+	require.NoError(t, err)
+	size, err = file.Size()
+	require.NoError(t, err)
+	require.Equal(t, size, int64(56000))
+
+	require.NoError(t, tx.Close())
+	// Check the global blockstore now has the blocks
+	_, err = utils.Stat(ctx, &multistore.Store{Bstore: client.opts.Blockstore}, root, sel.All())
+	require.NoError(t, err)
+
+	// Get will by default create a new store if it's been deleted
+	store, err := tx.ms.Get(tx.StoreID())
+	require.NoError(t, err)
+	// That new store should not have our blocks
+	has, err := store.Bstore.Has(root)
+	require.NoError(t, err)
+	require.False(t, has)
 }
+
 func genTestFiles(t *testing.T) (map[string]string, []string) {
 	dir := t.TempDir()
 

--- a/exchange/tx_test.go
+++ b/exchange/tx_test.go
@@ -335,10 +335,15 @@ func TestMapFieldSelector(t *testing.T) {
 	pn.rtv.Provider().SetAsk(tx.Root(), resp)
 	require.NoError(t, qs.WriteQueryResponse(resp))
 
-	select {
-	case <-gtx.Done():
-	case <-ctx.Done():
-		t.Fatal("transaction could not complete")
+loop:
+	for {
+		select {
+		case <-gtx.Ongoing():
+		case <-gtx.Done():
+			break loop
+		case <-ctx.Done():
+			t.Fatal("transaction could not complete")
+		}
 	}
 	fnd, err := gtx.GetFile(key)
 	require.NoError(t, err)

--- a/internal/utils/stat.go
+++ b/internal/utils/stat.go
@@ -123,3 +123,25 @@ func MapKeys(ctx context.Context, root cid.Cid, loader ipld.Loader) (KeyList, er
 	}
 	return KeyList(entries), nil
 }
+
+// MigrateBlocks transfers all blocks from a blockstore to another
+func MigrateBlocks(ctx context.Context, from blockstore.Blockstore, to blockstore.Blockstore) error {
+	kchan, err := from.AllKeysChan(ctx)
+	if err != nil {
+		return err
+	}
+	for k := range kchan {
+		if err != nil {
+			return err
+		}
+		blk, err := from.Get(k)
+		if err != nil {
+			return err
+		}
+		err = to.Put(blk)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -484,7 +484,7 @@ func TestMultipleGet(t *testing.T) {
 
 	pn := newTestNode(bgCtx, mn, t)
 	cn := newTestNode(bgCtx, mn, t)
-	cn2 := newTestNode(bgCtx, mn, t)
+	// cn2 := newTestNode(bgCtx, mn, t)
 
 	require.NoError(t, mn.LinkAll())
 	require.NoError(t, mn.ConnectAllButSelf())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -577,19 +577,19 @@ func TestMultipleGet(t *testing.T) {
 	require.Greater(t, res.TransLatSeconds, 0.0)
 
 	// @BUG: not entirely sure why this doesn't work if data2 isn't fetched first
-	got3 := make(chan *GetResult, 2)
-	cn2.notify = func(n Notify) {
-		require.Equal(t, "", n.GetResult.Err)
-		got3 <- n.GetResult
-	}
-	cn2.Get(ctx, &GetArgs{
-		Cid:      fmt.Sprintf("/%s/data2", ref.PayloadCID.String()),
-		Strategy: "SelectFirst",
-		Timeout:  1,
-	})
-	res = <-got3
-	require.NotEqual(t, "", res.DealID)
+	// got3 := make(chan *GetResult, 2)
+	// cn2.notify = func(n Notify) {
+	// 	require.Equal(t, "", n.GetResult.Err)
+	// 	got3 <- n.GetResult
+	// }
+	// cn2.Get(ctx, &GetArgs{
+	// 	Cid:      fmt.Sprintf("/%s/data2", ref.PayloadCID.String()),
+	// 	Strategy: "SelectFirst",
+	// 	Timeout:  1,
+	// })
+	// res = <-got3
+	// require.NotEqual(t, "", res.DealID)
 
-	res = <-got3
-	require.Greater(t, res.TransLatSeconds, 0.0)
+	// res = <-got3
+	// require.Greater(t, res.TransLatSeconds, 0.0)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -347,7 +347,7 @@ func TestCommit(t *testing.T) {
 	})
 	<-added
 
-	committed := make(chan []string, 2)
+	committed := make(chan []string, 3)
 	cn.notify = func(n Notify) {
 		require.Equal(t, n.CommResult.Err, "")
 		committed <- n.CommResult.Caches
@@ -399,7 +399,16 @@ func TestGet(t *testing.T) {
 
 	ref, err := pn.getRef("")
 	require.NoError(t, err)
-	require.NoError(t, pn.exch.Index().SetRef(ref))
+	committed := make(chan struct{}, 1)
+	pn.notify = func(n Notify) {
+		require.Equal(t, n.CommResult.Err, "")
+		committed <- struct{}{}
+	}
+	pn.Commit(ctx, &CommArgs{
+		CacheRF:   0,
+		StorageRF: 0,
+	})
+	<-committed
 
 	got := make(chan *GetResult, 2)
 	cn.notify = func(n Notify) {
@@ -475,7 +484,7 @@ func TestMultipleGet(t *testing.T) {
 
 	pn := newTestNode(bgCtx, mn, t)
 	cn := newTestNode(bgCtx, mn, t)
-	//cn2 := newTestNode(bgCtx, mn, t)
+	cn2 := newTestNode(bgCtx, mn, t)
 
 	require.NoError(t, mn.LinkAll())
 	require.NoError(t, mn.ConnectAllButSelf())
@@ -523,7 +532,16 @@ func TestMultipleGet(t *testing.T) {
 
 	ref, err := pn.getRef("")
 	require.NoError(t, err)
-	require.NoError(t, pn.exch.Index().SetRef(ref))
+	committed := make(chan struct{}, 1)
+	pn.notify = func(n Notify) {
+		require.Equal(t, n.CommResult.Err, "")
+		committed <- struct{}{}
+	}
+	pn.Commit(ctx, &CommArgs{
+		CacheRF:   0,
+		StorageRF: 0,
+	})
+	<-committed
 
 	got1 := make(chan *GetResult, 2)
 	cn.notify = func(n Notify) {
@@ -559,19 +577,19 @@ func TestMultipleGet(t *testing.T) {
 	require.Greater(t, res.TransLatSeconds, 0.0)
 
 	// @BUG: not entirely sure why this doesn't work if data2 isn't fetched first
-	// got3 := make(chan *GetResult, 2)
-	// cn2.notify = func(n Notify) {
-	// 	require.Equal(t, "", n.GetResult.Err)
-	// 	got3 <- n.GetResult
-	// }
-	// cn2.Get(ctx, &GetArgs{
-	// 	Cid:      fmt.Sprintf("/%s/data2", ref.PayloadCID.String()),
-	// 	Strategy: "SelectFirst",
-	// 	Timeout:  1,
-	// })
-	// res = <-got3
-	// require.NotEqual(t, "", res.DealID)
+	got3 := make(chan *GetResult, 2)
+	cn2.notify = func(n Notify) {
+		require.Equal(t, "", n.GetResult.Err)
+		got3 <- n.GetResult
+	}
+	cn2.Get(ctx, &GetArgs{
+		Cid:      fmt.Sprintf("/%s/data2", ref.PayloadCID.String()),
+		Strategy: "SelectFirst",
+		Timeout:  1,
+	})
+	res = <-got3
+	require.NotEqual(t, "", res.DealID)
 
-	// res = <-got3
-	// require.Greater(t, res.TransLatSeconds, 0.0)
+	res = <-got3
+	require.Greater(t, res.TransLatSeconds, 0.0)
 }

--- a/retrieval/environments.go
+++ b/retrieval/environments.go
@@ -131,7 +131,7 @@ func (pve *providerValidationEnvironment) BeginTracking(pds deal.ProviderState) 
 
 // GetStoreID finds a store where our content is currently
 func (pve *providerValidationEnvironment) GetStoreID(c cid.Cid) (multistore.StoreID, error) {
-	return pve.p.storeIDGetter.GetStoreID(c)
+	return 0, nil
 }
 
 // NextStoreID allocates a store for this deal TODO: do we still need this?

--- a/retrieval/gsconfig.go
+++ b/retrieval/gsconfig.go
@@ -56,13 +56,8 @@ type dualStoreGetter struct {
 // Our transport handles both client and provider as a result we need to try both states see which one works
 // TODO: figure out how to improve so we don't cause unnecessary reads on the client side
 func (dsg *dualStoreGetter) Get(pid peer.ID, did deal.ID) (*multistore.Store, error) {
-	var pstate deal.ProviderState
-	err := dsg.p.stateMachines.Get(deal.ProviderDealIdentifier{Receiver: pid, DealID: did}).Get(&pstate)
-	if err == nil {
-		return dsg.p.multiStore.Get(pstate.StoreID)
-	}
 	var cstate deal.ClientState
-	err = dsg.c.stateMachines.Get(did).Get(&cstate)
+	err := dsg.c.stateMachines.Get(did).Get(&cstate)
 	if err == nil {
 		return dsg.c.multiStore.Get(*cstate.StoreID)
 	}

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -82,7 +82,6 @@ type Provider struct {
 	revalidator      *ProviderRevalidator
 	pay              payments.Manager
 	askStore         *AskStore
-	storeIDGetter    StoreIDGetter
 }
 
 // GetAsk returns the current deal parameters this provider accepts for a given content ID
@@ -120,7 +119,6 @@ func New(
 	ds datastore.Batching,
 	pay payments.Manager,
 	dt datatransfer.Manager,
-	sg StoreIDGetter,
 	self peer.ID,
 ) (Manager, error) {
 	var err error
@@ -152,7 +150,6 @@ func New(
 		askStore: &AskStore{
 			asks: make(map[cid.Cid]deal.QueryResponse),
 		},
-		storeIDGetter: sg,
 	}
 	p.stateMachines, err = fsm.New(namespace.Wrap(ds, datastore.NewKey("provider-v0")), fsm.Parameters{
 		Environment:     &providerDealEnvironment{p},

--- a/testplans/go.mod
+++ b/testplans/go.mod
@@ -18,8 +18,9 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-kad-dht v0.11.1
 	github.com/libp2p/go-libp2p-pubsub v0.4.1
-	github.com/myelnet/pop v0.0.0-20210503100713-0b177bff7a5b
+	github.com/myelnet/pop v0.0.0-20210609151900-0a6bc3b1e279
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/testground/sdk-go v0.2.7
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/testplans/go.sum
+++ b/testplans/go.sum
@@ -53,6 +53,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bep/debounce v1.2.0/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
@@ -151,6 +152,7 @@ github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod 
 github.com/filecoin-project/go-data-transfer v1.0.1/go.mod h1:UxvfUAY9v3ub0a21BSK9u3pB2aq30Y0KMsG+w9/ysyo=
 github.com/filecoin-project/go-data-transfer v1.4.3 h1:ECEw69NOfmEZ7XN1NSBvj3KTbbH2mIczQs+Z2w4bD7c=
 github.com/filecoin-project/go-data-transfer v1.4.3/go.mod h1:n8kbDQXWrY1c4UgfMa9KERxNCWbOTDwdNhf2MpN9dpo=
+github.com/filecoin-project/go-data-transfer v1.6.0/go.mod h1:E3WW4mCEYwU2y65swPEajSZoFWFmfXt7uwGduoACZQc=
 github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl8btmWxyFMEeeWGUxIQ=
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
@@ -158,6 +160,7 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20201016201715-d41df56b4f6a/go
 github.com/filecoin-project/go-fil-markets v1.0.5-0.20201113164554-c5eba40d5335/go.mod h1:AJySOJC00JRWEZzRG2KsfUnqEf5ITXxeX09BE9N4f9c=
 github.com/filecoin-project/go-fil-markets v1.2.5 h1:bQgtXbwxKyPxSEQoUI5EaTHJ0qfzyd5NosspuADCm6Y=
 github.com/filecoin-project/go-fil-markets v1.2.5/go.mod h1:7JIqNBmFvOyBzk/EiPYnweVdQnWhshixb5B9b1653Ag=
+github.com/filecoin-project/go-fil-markets v1.4.0/go.mod h1:7be6zzFwaN8kxVeYZf/UUj/JilHC0ogPvWqE1TW8Ptk=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=
@@ -214,6 +217,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-redis/redis/v7 v7.4.0 h1:7obg6wUoj05T0EpY0o8B59S9w5yeMWql7sw2kwNW1x4=
 github.com/go-redis/redis/v7 v7.4.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -271,6 +275,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -368,6 +373,7 @@ github.com/ipfs/go-graphsync v0.1.0/go.mod h1:jMXfqIEDFukLPZHqDPp8tJMbHO9Rmeb9CE
 github.com/ipfs/go-graphsync v0.4.2/go.mod h1:/VmbZTUdUMTbNkgzAiCEucIIAU3BkLE2cZrDCVUhyi0=
 github.com/ipfs/go-graphsync v0.4.3/go.mod h1:mPOwDYv128gf8gxPFgXnz4fNrSYPsWyqisJ7ych+XDY=
 github.com/ipfs/go-graphsync v0.6.0/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
+github.com/ipfs/go-graphsync v0.6.1/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
 github.com/ipfs/go-graphsync v0.7.0 h1:ZdyU2otZYPjcvduAPwVjCdijmkPtHI1mm1VyZbRQ5KI=
 github.com/ipfs/go-graphsync v0.7.0/go.mod h1:YRQg0TyvD2HzFansAZdMcUFBJ8zIJ4K+32kNdnHfHZc=
 github.com/ipfs/go-hamt-ipld v0.0.15-0.20200131012125-dd88a59d3f2e/go.mod h1:9aQJu/i/TaRDW6jqB5U217dLIDopn50wxLdHXM2CTfE=
@@ -922,12 +928,15 @@ github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/myelnet/pop v0.0.0-20210503100713-0b177bff7a5b h1:AChQpOsz6iDtwPodBOZ995r5kqahKMPJNODnpfeH8Ik=
 github.com/myelnet/pop v0.0.0-20210503100713-0b177bff7a5b/go.mod h1:tOUZAage6EVO5BPiwLZO/cNWGkLi9KGEiQUZcypYkUU=
+github.com/myelnet/pop v0.0.0-20210609151900-0a6bc3b1e279 h1:Qfy1qJv7VO8aX+7W2f//cQdXJ+kHLOgHMiIuPUYdmyY=
+github.com/myelnet/pop v0.0.0-20210609151900-0a6bc3b1e279/go.mod h1:pxGow6EJBTTYiZTT+1Hz/6vZvO0HZvyjr5yotokaQ08=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -937,6 +946,7 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -946,6 +956,7 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
@@ -1060,6 +1071,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/supranational/blst v0.3.2 h1:66jX8gjJwG738kKvvzeo6DNigXcl+mBFwnhx33TY9FI=
 github.com/supranational/blst v0.3.2/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
@@ -1176,6 +1188,7 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 h1:gzMM0EjIYiRmJI3+jBdFuoynZlpxa2JQZsolKu09BXo=
 golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1243,9 +1256,11 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 h1:b0LrWgu8+q7z4J+0Y3Umo5q1dL7NXBkKBWkaVkAq17E=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210420210106-798c2154c571/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1312,10 +1327,12 @@ golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e h1:XNp2Flc/1eWQGk5BLzqTAN7fQIwIbfyVTuVxXxZh73M=
 golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1324,6 +1341,7 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1365,6 +1383,7 @@ golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200711155855-7342f9734a7d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200827010519-17fd2f27a9e3/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.1-0.20210225150353-54dc8c5edb56 h1:g3QwFWCjsUzBtcQIcI+CYmiL/0i0BxTJjQp54GGDLEM=
 golang.org/x/tools v0.1.1-0.20210225150353-54dc8c5edb56/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
@@ -1454,6 +1473,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=


### PR DESCRIPTION
- This PR flushes all content from transactions into a global blockstore upon closing. This means that multi stores are only used for a given transaction then discarded when the transaction is completed. 
- The implementer is responsible for adding the transaction ref to the index. I'm still considering adding it by default in the Commit method but it seems decoupling it from the transaction adds more flexibility.
- If the transaction is closed before a transfer succeeds or the transaction is committed the store and all it data will be discarded.
- This blockstore is also the default loaded by the data transfer manager hence any transport configurer will fall back to it if they cannot find a valid multistore for a request.
- In addition, the storage client will also use that blockstore for sending to storage miners. This makes it easier to combine content from multiple transactions into a single storage deal.
- Lastly, the DataRef does not hold store IDs anymore as it is not needed.