### PR TITLE
fix: replication diff regions race

### DIFF
--- a/exchange/peermgr.go
+++ b/exchange/peermgr.go
@@ -94,9 +94,12 @@ func (pm *PeerMgr) RecordLatency(p peer.ID, t time.Duration) error {
 
 // Peers returns n active peers for a given list of regions and peers to ignore
 func (pm *PeerMgr) Peers(n int, rl []Region, ignore map[peer.ID]bool) []peer.ID {
+	var peers []peer.ID
+	if n == 0 {
+		return peers
+	}
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-	var peers []peer.ID
 	for _, r := range rl {
 		for p, v := range pm.peers {
 			if ignore[p] {

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -528,6 +528,7 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 					out <- r
 					// increment our results count
 					n++
+					fmt.Println("incrementing n", n)
 					if n == opt.RF {
 						return
 					}

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -467,6 +467,7 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 			}
 			// The recipient is the provider who received our content
 			rec := chState.Recipient()
+			fmt.Println("publishing record")
 			resChan <- PRecord{
 				Provider:   rec,
 				PayloadCID: root,
@@ -475,6 +476,7 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 	})
 	go func() {
 		defer func() {
+			fmt.Println("closing backoff")
 			unsub()
 			close(out)
 
@@ -512,13 +514,16 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 				r.sendAllRequests(req, providers)
 			}
 
-			timer := time.NewTimer(b.Duration())
+			delay := b.Duration()
+			timer := time.NewTimer(delay)
+			fmt.Println("timer", delay)
 			for {
 				select {
 				case <-timer.C:
 
 					continue requests
 				case r := <-resChan:
+					fmt.Println("result channel")
 					// forward the confirmations to the Response channel
 					out <- r
 					// increment our results count

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -388,6 +388,7 @@ func (r *Replication) handleRequest(s network.Stream) {
 
 			switch state.Status() {
 			case datatransfer.Failed, datatransfer.Cancelled:
+				fmt.Println("provider transfer failed")
 				err = r.idx.DropRef(state.BaseCID())
 				if err != nil {
 					fmt.Println("error when droping ref :", err)
@@ -466,7 +467,9 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 			return
 		}
 
-		fmt.Println("status", datatransfer.Statuses[chState.Status()], datatransfer.Events[event.Code])
+		if chState.Status() == datatransfer.Failed || chState.Status() == datatransfer.Cancelled {
+			fmt.Println("cient transfer failed")
+		}
 
 		if chState.Status() == datatransfer.Completed {
 			// The recipient is the provider who received our content

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -634,11 +634,6 @@ func TransportConfigurer(idx *Index, isg IdxStoreGetter, pid peer.ID) datatransf
 		if (request.Method == FetchIndex && channelID.Initiator == pid) || request.Method == Dispatch {
 			// When we're fetching a new index we store it in a new store
 			store := isg.GetStore(request.PayloadCID)
-
-			if channelID.Initiator != pid {
-				fmt.Println("got the store")
-			}
-
 			err := gsTransport.UseStore(channelID, store.Loader, store.Storer)
 			if err != nil {
 				warn(err)

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -354,6 +354,7 @@ func (r *Replication) handleRequest(s network.Stream) {
 	switch req.Method {
 	case Dispatch:
 		// TODO: validate request
+		fmt.Println("got a dispatch request")
 
 		// Check if we may already have this content
 		_, err := r.idx.GetRef(req.PayloadCID)
@@ -370,6 +371,7 @@ func (r *Replication) handleRequest(s network.Stream) {
 			return
 		}
 
+		fmt.Println("opening pull")
 		ctx := context.Background()
 		chid, err := r.dt.OpenPullDataChannel(ctx, p, &req, req.PayloadCID, sel.All())
 		if err != nil {
@@ -504,6 +506,7 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 				rcv[p] = true
 			}
 			if len(providers) > 0 {
+				fmt.Println("sending requests to providers", len(providers))
 				// sendAllRequests
 				r.sendAllRequests(req, providers)
 			}

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -492,6 +492,7 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 
 	requests:
 		for {
+			fmt.Println("attempting")
 			// Give up after 6 attemps. Maybe should make this customizable for servers that can afford it
 			if int(b.Attempt()) > opt.BackoffAttemps {
 				return

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -440,7 +440,7 @@ type DispatchOptions struct {
 // DefaultDispatchOptions provides useful defaults
 // We can change these if the content requires a long transfer time
 var DefaultDispatchOptions = DispatchOptions{
-	BackoffMin:     2 * time.Second,
+	BackoffMin:     5 * time.Second,
 	BackoffAttemps: 4,
 	RF:             6,
 }

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -395,6 +395,7 @@ func (r *Replication) handleRequest(s network.Stream) {
 				return
 
 			case datatransfer.Completed:
+				fmt.Println("provider transfer completed")
 				store := r.GetStore(req.PayloadCID)
 
 				keys, err := utils.MapKeys(ctx, req.PayloadCID, store.Loader)
@@ -637,6 +638,9 @@ func TransportConfigurer(idx *Index, isg IdxStoreGetter, pid peer.ID) datatransf
 		// with the root CID so we just need to get it
 		if (request.Method == FetchIndex && channelID.Initiator == pid) || request.Method == Dispatch {
 			// When we're fetching a new index we store it in a new store
+			if channelID.Initiator != pid {
+				fmt.Println("getting the store")
+			}
 			store := isg.GetStore(request.PayloadCID)
 			err := gsTransport.UseStore(channelID, store.Loader, store.Storer)
 			if err != nil {

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -354,7 +354,6 @@ func (r *Replication) handleRequest(s network.Stream) {
 	switch req.Method {
 	case Dispatch:
 		// TODO: validate request
-		fmt.Println("got a dispatch request")
 
 		// Check if we may already have this content
 		_, err := r.idx.GetRef(req.PayloadCID)
@@ -371,7 +370,6 @@ func (r *Replication) handleRequest(s network.Stream) {
 			return
 		}
 
-		fmt.Println("opening pull")
 		ctx := context.Background()
 		chid, err := r.dt.OpenPullDataChannel(ctx, p, &req, req.PayloadCID, sel.All())
 		if err != nil {
@@ -388,7 +386,6 @@ func (r *Replication) handleRequest(s network.Stream) {
 
 			switch state.Status() {
 			case datatransfer.Failed, datatransfer.Cancelled:
-				fmt.Println("provider transfer failed")
 				err = r.idx.DropRef(state.BaseCID())
 				if err != nil {
 					fmt.Println("error when droping ref :", err)
@@ -396,7 +393,6 @@ func (r *Replication) handleRequest(s network.Stream) {
 				return
 
 			case datatransfer.Completed:
-				fmt.Println("provider transfer completed")
 				store := r.GetStore(req.PayloadCID)
 
 				keys, err := utils.MapKeys(ctx, req.PayloadCID, store.Loader)
@@ -468,13 +464,12 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 		}
 
 		if chState.Status() == datatransfer.Failed || chState.Status() == datatransfer.Cancelled {
-			fmt.Println("cient transfer failed")
+			fmt.Println("transfer failed for content", root)
 		}
 
 		if chState.Status() == datatransfer.Completed {
 			// The recipient is the provider who received our content
 			rec := chState.Recipient()
-			fmt.Println("publishing record")
 			resChan <- PRecord{
 				Provider:   rec,
 				PayloadCID: root,
@@ -483,7 +478,6 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 	})
 	go func() {
 		defer func() {
-			fmt.Println("closing backoff")
 			unsub()
 			close(out)
 
@@ -501,7 +495,6 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 
 	requests:
 		for {
-			fmt.Println("attempting")
 			// Give up after 6 attemps. Maybe should make this customizable for servers that can afford it
 			if int(b.Attempt()) > opt.BackoffAttemps {
 				return
@@ -516,26 +509,22 @@ func (r *Replication) Dispatch(root cid.Cid, size uint64, opt DispatchOptions) (
 				rcv[p] = true
 			}
 			if len(providers) > 0 {
-				fmt.Println("sending requests to providers", len(providers))
 				// sendAllRequests
 				r.sendAllRequests(req, providers)
 			}
 
 			delay := b.Duration()
 			timer := time.NewTimer(delay)
-			fmt.Println("timer", delay)
 			for {
 				select {
 				case <-timer.C:
 
 					continue requests
 				case r := <-resChan:
-					fmt.Println("result channel")
 					// forward the confirmations to the Response channel
 					out <- r
 					// increment our results count
 					n++
-					fmt.Println("incrementing n", n)
 					if n == opt.RF {
 						return
 					}

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -693,7 +693,7 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 	}
 	// get 5 requests and give up after 4 attemps
 	options := DispatchOptions{
-		BackoffMin:     100 * time.Millisecond,
+		BackoffMin:     5 * time.Second,
 		BackoffAttemps: 4,
 		RF:             7,
 		StoreID:        storeID,

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -440,7 +440,7 @@ func TestConcurrentReplication(t *testing.T) {
 }
 
 func TestMultiDispatchStreams(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	mn := mocknet.New(ctx)

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -693,7 +693,7 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 	}
 	// get 5 requests and give up after 4 attemps
 	options := DispatchOptions{
-		BackoffMin:     5 * time.Second,
+		BackoffMin:     100 * time.Millisecond,
 		BackoffAttemps: 4,
 		RF:             7,
 		StoreID:        storeID,

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -711,3 +711,69 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 	}
 	require.Equal(t, 5, len(recipients))
 }
+
+func TestPeerMgr(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	mn := mocknet.New(ctx)
+
+	regions := []Region{
+		{
+			Name: "TestRegion",
+			Code: CustomRegion,
+		},
+	}
+
+	tnds := make(map[peer.ID]*testutil.TestNode)
+	receivers := make([]*Replication, 11)
+
+	for i := 0; i < 11; i++ {
+		tnode := testutil.NewTestNode(mn, t)
+		tnode.SetupDataTransfer(ctx, t)
+		t.Cleanup(func() {
+			err := tnode.Dt.Stop(ctx)
+			require.NoError(t, err)
+		})
+		idx, err := NewIndex(tnode.Ds)
+		require.NoError(t, err)
+		opts := Options{Regions: regions, MultiStore: tnode.Ms, Blockstore: tnode.Bs}
+		hn1 := NewReplication(tnode.Host, idx, tnode.Dt, NewMockRetriever(tnode.Dt, idx), opts)
+		require.NoError(t, hn1.Start(ctx))
+		receivers[i] = hn1
+		tnds[tnode.Host.ID()] = tnode
+	}
+
+	require.NoError(t, mn.LinkAll())
+
+	require.NoError(t, mn.ConnectAllButSelf())
+
+	time.Sleep(time.Second)
+
+	repl := receivers[0]
+	ignore := make(map[peer.ID]bool)
+
+	peers := repl.pm.Peers(6, regions, ignore)
+	require.Equal(t, 6, len(peers))
+
+	// Let's ignore a couple
+	ignore[peers[0]] = true
+	ignore[peers[1]] = true
+
+	peers2 := repl.pm.Peers(6, regions, ignore)
+	require.Equal(t, 6, len(peers2))
+	for _, pid := range peers2 {
+		if pid == peers[0] || pid == peers[1] {
+			t.Fatal("Peers did not ignore the right peers")
+		}
+	}
+
+	// Try to get more than available
+	peers3 := repl.pm.Peers(10, regions, ignore)
+	require.Equal(t, 8, len(peers3))
+
+	// 0 peers should return 0 peers
+	peers4 := repl.pm.Peers(0, regions, ignore)
+	require.Equal(t, 0, len(peers4))
+}

--- a/exchange/replication_test.go
+++ b/exchange/replication_test.go
@@ -693,7 +693,7 @@ func TestSendDispatchDiffRegions(t *testing.T) {
 	}
 	// get 5 requests and give up after 4 attemps
 	options := DispatchOptions{
-		BackoffMin:     100 * time.Millisecond,
+		BackoffMin:     200 * time.Millisecond,
 		BackoffAttemps: 4,
 		RF:             7,
 		StoreID:        storeID,


### PR DESCRIPTION
Seems like the issue was:
1) The backoff interval didn't leave enough time for all the transfers to complete so it would close the channel before all confirmations came through.
2) The transfers were sometimes too slow for the context timeout and would close before all completed.