### PR TITLE
feat: optional signers

### DIFF
--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
-	keystore "github.com/ipfs/go-ipfs-keystore"
 	"github.com/ipfs/go-merkledag"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-eventbus"
@@ -221,7 +220,6 @@ func TestExchangeE2E(t *testing.T) {
 					Blockstore: n.Bs,
 					MultiStore: n.Ms,
 					RepoPath:   n.DTTmpDir,
-					Keystore:   keystore.NewMemKeystore(),
 				}
 				exch, err := New(bgCtx, n.Host, n.Ds, opts)
 				require.NoError(t, err)
@@ -346,7 +344,6 @@ func TestExchangeJoiningNetwork(t *testing.T) {
 					Blockstore:   n.Bs,
 					MultiStore:   n.Ms,
 					RepoPath:     n.DTTmpDir,
-					Keystore:     keystore.NewMemKeystore(),
 					ReplInterval: 2 * time.Second,
 				}
 				exch, err := New(bgCtx, n.Host, n.Ds, opts)

--- a/exchange/hey.go
+++ b/exchange/hey.go
@@ -124,10 +124,7 @@ func (hs *HeyService) SendHey(ctx context.Context, pid peer.ID) error {
 	go func() {
 		defer s.Close()
 
-		err = s.SetReadDeadline(time.Now().Add(10 * time.Second))
-		if err != nil {
-			log.Error().Err(err).Msg("failed to set read deadline")
-		}
+		s.SetReadDeadline(time.Now().Add(10 * time.Second))
 
 		buf := make([]byte, 32)
 		_, err := io.ReadFull(s, buf)
@@ -137,10 +134,7 @@ func (hs *HeyService) SendHey(ctx context.Context, pid peer.ID) error {
 		now := time.Now()
 		lat := now.Sub(start)
 
-		err = hs.pm.RecordLatency(pid, lat)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to record latency")
-		}
+		hs.pm.RecordLatency(pid, lat)
 	}()
 	return nil
 }

--- a/exchange/tx_test.go
+++ b/exchange/tx_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/filecoin-project/go-multistore"
 	files "github.com/ipfs/go-ipfs-files"
-	keystore "github.com/ipfs/go-ipfs-keystore"
 	"github.com/ipfs/go-path"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
@@ -29,7 +28,6 @@ func TestTx(t *testing.T) {
 		n := testutil.NewTestNode(mn, t)
 		opts := Options{
 			RepoPath:     n.DTTmpDir,
-			Keystore:     keystore.NewMemKeystore(),
 			ReplInterval: -1,
 		}
 		exch, err := New(ctx, n.Host, n.Ds, opts)
@@ -151,7 +149,6 @@ func TestTxPutGet(t *testing.T) {
 	n := testutil.NewTestNode(mn, t)
 	opts := Options{
 		RepoPath: n.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	}
 	exch, err := New(ctx, n.Host, n.Ds, opts)
 	require.NoError(t, err)
@@ -214,7 +211,6 @@ func BenchmarkAdd(b *testing.B) {
 	n := testutil.NewTestNode(mn, b)
 	opts := Options{
 		RepoPath: n.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	}
 	exch, err := New(ctx, n.Host, n.Ds, opts)
 	require.NoError(b, err)
@@ -243,7 +239,6 @@ func TestTxRace(t *testing.T) {
 	n := testutil.NewTestNode(mn, t)
 	opts := Options{
 		RepoPath: n.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	}
 	exch, err := New(ctx, n.Host, n.Ds, opts)
 	require.NoError(t, err)
@@ -280,7 +275,6 @@ func TestMapFieldSelector(t *testing.T) {
 	n1 := testutil.NewTestNode(mn, t)
 	opts := Options{
 		RepoPath: n1.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	}
 	pn, err := New(ctx, n1.Host, n1.Ds, opts)
 	require.NoError(t, err)
@@ -288,7 +282,6 @@ func TestMapFieldSelector(t *testing.T) {
 	n2 := testutil.NewTestNode(mn, t)
 	cn, err := New(ctx, n2.Host, n2.Ds, Options{
 		RepoPath: n2.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	})
 	require.NoError(t, err)
 
@@ -327,7 +320,7 @@ func TestMapFieldSelector(t *testing.T) {
 	resp := deal.QueryResponse{
 		Status:                     deal.QueryResponseAvailable,
 		Size:                       uint64(tx.Size()),
-		PaymentAddress:             cn.w.DefaultAddress(),
+		PaymentAddress:             cn.opts.Wallet.DefaultAddress(),
 		MinPricePerByte:            global.PPB,
 		MaxPaymentInterval:         deal.DefaultPaymentInterval,
 		MaxPaymentIntervalIncrease: deal.DefaultPaymentIntervalIncrease,
@@ -365,7 +358,6 @@ func TestMultiTx(t *testing.T) {
 	n1 := testutil.NewTestNode(mn, t)
 	opts := Options{
 		RepoPath: n1.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	}
 	pn, err := New(ctx, n1.Host, n1.Ds, opts)
 	require.NoError(t, err)
@@ -373,14 +365,12 @@ func TestMultiTx(t *testing.T) {
 	n2 := testutil.NewTestNode(mn, t)
 	cn1, err := New(ctx, n2.Host, n2.Ds, Options{
 		RepoPath: n2.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	})
 	require.NoError(t, err)
 
 	n3 := testutil.NewTestNode(mn, t)
 	_, err = New(ctx, n3.Host, n3.Ds, Options{
 		RepoPath: n3.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	})
 	require.NoError(t, err)
 
@@ -446,7 +436,6 @@ func TestTxGetEntries(t *testing.T) {
 	n1 := testutil.NewTestNode(mn, t)
 	opts := Options{
 		RepoPath: n1.DTTmpDir,
-		Keystore: keystore.NewMemKeystore(),
 	}
 	pn, err := New(ctx, n1.Host, n1.Ds, opts)
 	require.NoError(t, err)

--- a/node/bls.go
+++ b/node/bls.go
@@ -1,4 +1,4 @@
-package wallet
+package node
 
 import (
 	"crypto/rand"

--- a/node/popn.go
+++ b/node/popn.go
@@ -198,7 +198,6 @@ func New(ctx context.Context, opts Options) (*node, error) {
 	eopts := exchange.Options{
 		Blockstore:          nd.bs,
 		MultiStore:          nd.ms,
-		Keystore:            ks,
 		RepoPath:            opts.RepoPath,
 		FilecoinRPCEndpoint: opts.FilEndpoint,
 		FilecoinRPCHeader: http.Header{
@@ -208,6 +207,16 @@ func New(ctx context.Context, opts Options) (*node, error) {
 		Capacity:     opts.Capacity,
 		ReplInterval: opts.ReplInterval,
 	}
+
+	eopts.FilecoinAPI, err = filecoin.NewLotusRPC(ctx, eopts.FilecoinRPCEndpoint, eopts.FilecoinRPCHeader)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to connect with Lotus RPC")
+	}
+	eopts.Wallet = wallet.NewFromKeystore(
+		ks,
+		wallet.WithFilAPI(eopts.FilecoinAPI),
+		wallet.WithBLSSig(bls{}),
+	)
 
 	nd.exch, err = exchange.New(ctx, nd.host, nd.ds, eopts)
 	if err != nil {

--- a/payments/channel.go
+++ b/payments/channel.go
@@ -757,7 +757,7 @@ func (ch *channel) checkVoucherValidUnlocked(ctx context.Context, chAddr address
 		return nil, err
 	}
 
-	sig, err := wallet.SigTypeSig(sv.Signature.Type)
+	sig, err := wallet.SigTypeSig(sv.Signature.Type, ch.wal.Signers())
 	if err != nil {
 		return nil, err
 	}

--- a/payments/channel_test.go
+++ b/payments/channel_test.go
@@ -71,7 +71,7 @@ func TestChannel(t *testing.T) {
 
 	ks := keystore.NewMemKeystore()
 
-	w := wallet.NewFromKeystore(ks, api)
+	w := wallet.NewFromKeystore(ks, wallet.WithFilAPI(api))
 
 	addr1, err := w.NewKey(ctx, wallet.KTSecp256k1)
 	require.NoError(t, err)
@@ -293,7 +293,7 @@ func TestLoadActorState(t *testing.T) {
 
 	api.SetObject([]byte("testing"))
 
-	w := wallet.NewFromKeystore(ks, api)
+	w := wallet.NewFromKeystore(ks, wallet.WithFilAPI(api))
 
 	store := NewStore(dssync.MutexWrap(ds.NewMapDatastore()))
 	cborstore := cbor.NewCborStore(&mockBlocks{make(map[cid.Cid]block.Block)})

--- a/payments/manager_test.go
+++ b/payments/manager_test.go
@@ -33,7 +33,7 @@ func TestAddFunds(t *testing.T) {
 
 	ks := keystore.NewMemKeystore()
 
-	w := wallet.NewFromKeystore(ks, api)
+	w := wallet.NewFromKeystore(ks, wallet.WithFilAPI(api))
 
 	addr1, err := w.NewKey(ctx, wallet.KTSecp256k1)
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 
 	ks := keystore.NewMemKeystore()
 
-	w := wallet.NewFromKeystore(ks, api)
+	w := wallet.NewFromKeystore(ks, wallet.WithFilAPI(api))
 
 	from, err := w.NewKey(ctx, wallet.KTSecp256k1)
 	require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestBestSpendable(t *testing.T) {
 
 	ks := keystore.NewMemKeystore()
 
-	w := wallet.NewFromKeystore(ks, api)
+	w := wallet.NewFromKeystore(ks, wallet.WithFilAPI(api))
 
 	from, err := w.NewKey(ctx, wallet.KTSecp256k1)
 	require.NoError(t, err)
@@ -405,7 +405,7 @@ func TestCollectChannel(t *testing.T) {
 
 	ks := keystore.NewMemKeystore()
 
-	w := wallet.NewFromKeystore(ks, api)
+	w := wallet.NewFromKeystore(ks, wallet.WithFilAPI(api))
 
 	from, err := w.NewKey(ctx, wallet.KTSecp256k1)
 	require.NoError(t, err)

--- a/testplans/go.mod
+++ b/testplans/go.mod
@@ -18,9 +18,11 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-kad-dht v0.11.1
 	github.com/libp2p/go-libp2p-pubsub v0.4.1
-	github.com/myelnet/pop v0.0.0-20210609151900-0a6bc3b1e279
+	github.com/myelnet/pop v0.0.0-20210614104917-8c6927bf7dfd
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/peterbourgon/ff/v2 v2.0.0 // indirect
 	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/supranational/blst v0.3.2 // indirect
 	github.com/testground/sdk-go v0.2.7
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/testplans/go.sum
+++ b/testplans/go.sum
@@ -133,6 +133,7 @@ github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.m
 github.com/filecoin-project/go-address v0.0.3/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-address v0.0.5-0.20201103152444-f2023ef3f5bb h1:Cbu7YYsXHtVlPEJ+eqbBx2S3ElmWCB0NjpGPYvvvCrA=
 github.com/filecoin-project/go-address v0.0.5-0.20201103152444-f2023ef3f5bb/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
+github.com/filecoin-project/go-address v0.0.5/go.mod h1:jr8JxKsYx+lQlQZmF5i2U0Z+cGQ59wMIps/8YW/lDj8=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.0/go.mod h1:nfFPoGyX0CU9SkXX8EoCcSuHN1XcbN0c6KBh7yvP5fs=
 github.com/filecoin-project/go-amt-ipld/v2 v2.1.1-0.20201006184820-924ee87a1349 h1:pIuR0dnMD0i+as8wNnjjHyQrnhP5O5bmba/lmgQeRgU=
@@ -143,16 +144,19 @@ github.com/filecoin-project/go-bitfield v0.0.1/go.mod h1:Ry9/iUlWSyjPUzlAvdnfy4G
 github.com/filecoin-project/go-bitfield v0.2.0/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
 github.com/filecoin-project/go-bitfield v0.2.3-0.20201110211213-fe2c1862e816 h1:RMdzMqe3mu2Z/3N3b9UEfkbGZxukstmZgNC024ybWhA=
 github.com/filecoin-project/go-bitfield v0.2.3-0.20201110211213-fe2c1862e816/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
+github.com/filecoin-project/go-bitfield v0.2.3/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-cbor-util v0.0.0-20201016124514-d0bbec7bfcc4 h1:YmE80qPn5K0txSqxnRNiCRAWyXI1LTO//I4c4H0QwbM=
 github.com/filecoin-project/go-cbor-util v0.0.0-20201016124514-d0bbec7bfcc4/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-commp-utils v0.0.0-20201119054358-b88f7a96a434/go.mod h1:6s95K91mCyHY51RPWECZieD3SGWTqIFLf1mPOes9l5U=
+github.com/filecoin-project/go-commp-utils v0.1.1-0.20210427191551-70bf140d31c7/go.mod h1:6s95K91mCyHY51RPWECZieD3SGWTqIFLf1mPOes9l5U=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-data-transfer v1.0.1/go.mod h1:UxvfUAY9v3ub0a21BSK9u3pB2aq30Y0KMsG+w9/ysyo=
 github.com/filecoin-project/go-data-transfer v1.4.3 h1:ECEw69NOfmEZ7XN1NSBvj3KTbbH2mIczQs+Z2w4bD7c=
 github.com/filecoin-project/go-data-transfer v1.4.3/go.mod h1:n8kbDQXWrY1c4UgfMa9KERxNCWbOTDwdNhf2MpN9dpo=
 github.com/filecoin-project/go-data-transfer v1.6.0/go.mod h1:E3WW4mCEYwU2y65swPEajSZoFWFmfXt7uwGduoACZQc=
+github.com/filecoin-project/go-data-transfer v1.7.0/go.mod h1:GLRr5BmLEqsLwXfiRDG7uJvph22KGL2M4iOuF8EINaU=
 github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl8btmWxyFMEeeWGUxIQ=
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
@@ -161,12 +165,14 @@ github.com/filecoin-project/go-fil-markets v1.0.5-0.20201113164554-c5eba40d5335/
 github.com/filecoin-project/go-fil-markets v1.2.5 h1:bQgtXbwxKyPxSEQoUI5EaTHJ0qfzyd5NosspuADCm6Y=
 github.com/filecoin-project/go-fil-markets v1.2.5/go.mod h1:7JIqNBmFvOyBzk/EiPYnweVdQnWhshixb5B9b1653Ag=
 github.com/filecoin-project/go-fil-markets v1.4.0/go.mod h1:7be6zzFwaN8kxVeYZf/UUj/JilHC0ogPvWqE1TW8Ptk=
+github.com/filecoin-project/go-fil-markets v1.6.0-rc1/go.mod h1:S/C9PcSLFp75NpaF5aUqutnhXVJk6hM2dhWPYNq2jCQ=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
 github.com/filecoin-project/go-hamt-ipld/v3 v3.0.0 h1:aEOgJxSMbJ7XtuX3WxXvbpkBDp4Sqn3jyx/umGyL8s4=
 github.com/filecoin-project/go-hamt-ipld/v3 v3.0.0/go.mod h1:gXpNmr3oQx8l3o7qkGyDjJjYSRX7hp/FGOStdqrWyDI=
+github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1/go.mod h1:gXpNmr3oQx8l3o7qkGyDjJjYSRX7hp/FGOStdqrWyDI=
 github.com/filecoin-project/go-jsonrpc v0.1.2 h1:MTebUawBHLxxY9gDi1WXuGc89TWIDmsgoDqeZSk9KRw=
 github.com/filecoin-project/go-jsonrpc v0.1.2/go.mod h1:XBBpuKIMaXIIzeqzO1iucq4GvbF8CxmXRFoezRh+Cx4=
 github.com/filecoin-project/go-multistore v0.0.3 h1:vaRBY4YiA2UZFPK57RNuewypB8u0DzzQwqsL0XarpnI=
@@ -178,6 +184,8 @@ github.com/filecoin-project/go-state-types v0.0.0-20200928172055-2df22083d8ab/go
 github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-state-types v0.0.0-20210119062722-4adba5aaea71 h1:Cas/CUB4ybYpdxvW7LouaydE16cpwdq3vvS3qgZuU+Q=
 github.com/filecoin-project/go-state-types v0.0.0-20210119062722-4adba5aaea71/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
+github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
@@ -192,8 +200,10 @@ github.com/filecoin-project/specs-actors/v2 v2.0.1/go.mod h1:v2NZVYinNIKA9acEMBm
 github.com/filecoin-project/specs-actors/v2 v2.3.2/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
 github.com/filecoin-project/specs-actors/v2 v2.3.4 h1:NZK2oMCcA71wNsUzDBmLQyRMzcCnX9tDGvwZ53G67j8=
 github.com/filecoin-project/specs-actors/v2 v2.3.4/go.mod h1:UuJQLoTx/HPvvWeqlIFmC/ywlOLHNe8SNQ3OunFbu2Y=
+github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb/go.mod h1:LljnY2Mn2homxZsmokJZCpRuhOPxfXhvcek5gWkmqAc=
 github.com/filecoin-project/specs-actors/v3 v3.0.0 h1:hX5LrLSmZsSAV+VoDYucEpiy8Iv3arF+9Lc4Ig7VlXM=
 github.com/filecoin-project/specs-actors/v3 v3.0.0/go.mod h1:aVf248CfjfyCmVel4UuFAA3u+9UQjqtqHpgfYv+M+9U=
+github.com/filecoin-project/specs-actors/v3 v3.1.0/go.mod h1:mpynccOLlIRy0QnR008BwYBwT9fen+sPR13MA1VmMww=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
@@ -374,6 +384,7 @@ github.com/ipfs/go-graphsync v0.4.2/go.mod h1:/VmbZTUdUMTbNkgzAiCEucIIAU3BkLE2cZ
 github.com/ipfs/go-graphsync v0.4.3/go.mod h1:mPOwDYv128gf8gxPFgXnz4fNrSYPsWyqisJ7ych+XDY=
 github.com/ipfs/go-graphsync v0.6.0/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
 github.com/ipfs/go-graphsync v0.6.1/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
+github.com/ipfs/go-graphsync v0.6.4/go.mod h1:5WyaeigpNdpiYQuW2vwpuecOoEfB4h747ZGEOKmAGTg=
 github.com/ipfs/go-graphsync v0.7.0 h1:ZdyU2otZYPjcvduAPwVjCdijmkPtHI1mm1VyZbRQ5KI=
 github.com/ipfs/go-graphsync v0.7.0/go.mod h1:YRQg0TyvD2HzFansAZdMcUFBJ8zIJ4K+32kNdnHfHZc=
 github.com/ipfs/go-hamt-ipld v0.0.15-0.20200131012125-dd88a59d3f2e/go.mod h1:9aQJu/i/TaRDW6jqB5U217dLIDopn50wxLdHXM2CTfE=
@@ -525,6 +536,7 @@ github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d/go.mod h1:5Ky9EC2xfo
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -930,6 +942,8 @@ github.com/myelnet/pop v0.0.0-20210503100713-0b177bff7a5b h1:AChQpOsz6iDtwPodBOZ
 github.com/myelnet/pop v0.0.0-20210503100713-0b177bff7a5b/go.mod h1:tOUZAage6EVO5BPiwLZO/cNWGkLi9KGEiQUZcypYkUU=
 github.com/myelnet/pop v0.0.0-20210609151900-0a6bc3b1e279 h1:Qfy1qJv7VO8aX+7W2f//cQdXJ+kHLOgHMiIuPUYdmyY=
 github.com/myelnet/pop v0.0.0-20210609151900-0a6bc3b1e279/go.mod h1:pxGow6EJBTTYiZTT+1Hz/6vZvO0HZvyjr5yotokaQ08=
+github.com/myelnet/pop v0.0.0-20210614104917-8c6927bf7dfd h1:6hoZtw8k68il9WHrWe4lbEw1OR8h3Azs/Qwi86Py5mE=
+github.com/myelnet/pop v0.0.0-20210614104917-8c6927bf7dfd/go.mod h1:yz3vnoBmK7pXd2WfbPqJrrNDVBPbbrnbZL5wUiQPA0g=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
@@ -965,6 +979,7 @@ github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTm
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/peterbourgon/ff/v2 v2.0.0/go.mod h1:xjwr+t+SjWm4L46fcj/D+Ap+6ME7+HqFzaP22pP5Ggk=
+github.com/peterbourgon/ff/v3 v3.0.0/go.mod h1:UILIFjRH5a/ar8TjXYLTkIvSvekZqPm5Eb/qbGk6CT0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -1103,6 +1118,7 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20200806213330-63aa96ca5488/go.mod h1:f
 github.com/whyrusleeping/cbor-gen v0.0.0-20200810223238-211df3b9e24c/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200826160007-0b9f6c5fb163/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20210118024343-169e9d70c0c2/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2 h1:bsUlNhdmbtlfdLVXAVfuvKQ01RnWAM09TVrJkI7NZs4=
 github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=

--- a/testplans/replication.go
+++ b/testplans/replication.go
@@ -92,6 +92,10 @@ func runBootstrapSupply(runenv *runtime.RunEnv, initCtx *run.InitContext) error 
 				return err
 			}
 			roots[i] = tx.Root()
+			err = tx.Close()
+			if err != nil {
+				return err
+			}
 		}
 
 		// Add few random reads
@@ -206,6 +210,10 @@ func runDispatch(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 			runenv.RecordMessage("sent to peer %s", rec.Provider)
 		})
 
+		err = tx.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = initCtx.SyncClient.SignalAndWait(ctx, "completed", runenv.TestInstanceCount)

--- a/testplans/routing.go
+++ b/testplans/routing.go
@@ -66,7 +66,6 @@ func runGossip(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	if err != nil {
 		return err
 	}
-	ms := settings.MultiStore
 
 	settings.Regions = ex.ParseRegions(runenv.StringArrayParam("regions"))
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -2,8 +2,6 @@ package wallet
 
 import (
 	"context"
-	"encoding/hex"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -25,7 +23,7 @@ func TestSecpSignature(t *testing.T) {
 	ctx := context.Background()
 	ks := keystore.NewMemKeystore()
 
-	w := NewFromKeystore(ks, nil)
+	w := NewFromKeystore(ks)
 
 	addr1, err := w.NewKey(ctx, KTSecp256k1)
 	if err != nil {
@@ -74,7 +72,7 @@ func TestDefaultAddress(t *testing.T) {
 	ctx := context.Background()
 	ks := keystore.NewMemKeystore()
 
-	w := NewFromKeystore(ks, nil)
+	w := NewFromKeystore(ks)
 
 	addr1, err := w.NewKey(ctx, KTSecp256k1)
 	require.NoError(t, err)
@@ -104,28 +102,6 @@ func TestDefaultAddress(t *testing.T) {
 	list, err := w.List()
 	require.NoError(t, err)
 	require.Equal(t, expected, list)
-}
-
-func TestImportKey(t *testing.T) {
-	ctx := context.Background()
-	ks := keystore.NewMemKeystore()
-
-	w := NewFromKeystore(ks, nil)
-
-	h := "7b2254797065223a22626c73222c22507269766174654b6579223a226a6b55704e6a53493749664a4632434f6f505169344f79477a475241532b766b616c314e5a616f7a3853633d227d"
-	decoded, _ := hex.DecodeString(h)
-
-	var ki KeyInfo
-	if err := json.Unmarshal(decoded, &ki); err != nil {
-		t.Fatal(err)
-	}
-
-	addr, err := w.ImportKey(ctx, &ki)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected, _ := address.NewFromString("f3w2ll4guubkslpmxseiqhtemwtmxdnhnshogd25gfrbhe6dso6kly2aj756wmcx2gq4jehn6x2z3ji4zlzioq")
-	require.Equal(t, expected, addr)
 }
 
 type testLotusNode struct{}
@@ -180,7 +156,7 @@ func TestTransfer(t *testing.T) {
 	defer api.Close()
 	ks := keystore.NewMemKeystore()
 
-	w := NewFromKeystore(ks, api)
+	w := NewFromKeystore(ks, WithFilAPI(api))
 
 	addr1, err := w.NewKey(ctx, KTSecp256k1)
 	if err != nil {


### PR DESCRIPTION
The goal of this PR is to remove exchange dependency on the filecoin-ffi so testing is more flexible when using in Testground environments. As a result, any exchange consumer can provide their own wallet interface and register custom signature interfaces. By default the exchange only supports secp256k1 so an external instance must be set in the options to register other signers such as BLS.