### PR TITLE
feat: lazy retrievals

### DIFF
--- a/cmd/pop/cli/get.go
+++ b/cmd/pop/cli/get.go
@@ -73,12 +73,12 @@ func runGet(ctx context.Context, args []string) error {
 			if gr.Err != "" {
 				return errors.New(gr.Err)
 			}
-			if gr.DealID != "" && gr.TotalPrice == "0" {
+			if gr.DealID != "" && gr.TotalFunds == "0" {
 				fmt.Printf("==> Started free transfer\n")
 				continue
 			}
 			if gr.DealID != "" {
-				fmt.Printf("==> Started retrieval deal %s for a total of %s (%s/b)\n", gr.DealID, gr.TotalPrice, gr.PricePerByte)
+				fmt.Printf("==> Started retrieval deal %s for a total of %s (%s/b)\n", gr.DealID, gr.TotalFunds, gr.PricePerByte)
 				continue
 			}
 			if gr.Local {
@@ -87,7 +87,7 @@ func runGet(ctx context.Context, args []string) error {
 			}
 
 			fmt.Printf("==> Completed\n")
-			if gr.TotalPrice != "0" {
+			if gr.TotalFunds != "0" {
 				fmt.Printf("Routing: %fs, Transfer: %fs, Total: %fs\n", gr.DiscLatSeconds, gr.TransLatSeconds, gr.DiscLatSeconds+gr.TransLatSeconds)
 			}
 

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -103,10 +103,9 @@ func New(ctx context.Context, h host.Host, ds datastore.Batching, opts Options) 
 }
 
 func (e *Exchange) handleQuery(ctx context.Context, p peer.ID, r Region, q deal.Query) (deal.Offer, error) {
-	_, err := e.idx.GetRef(q.PayloadCID)
-	if err != nil {
-		return deal.Offer{}, err
-	}
+	// This is used to increment LFU cache if the node is available
+	// the Stat method actually checks if the content is available.
+	_, _ = e.idx.GetRef(q.PayloadCID)
 	if q.Selector == nil {
 		return deal.Offer{}, fmt.Errorf("no selector provided")
 	}
@@ -115,7 +114,6 @@ func (e *Exchange) handleQuery(ctx context.Context, p peer.ID, r Region, q deal.
 		sel = selectors.All()
 	}
 	// DAGStat is both a way of checking if we have the blocks and returning its size
-	// TODO: support selector in Query
 	stats, err := utils.Stat(ctx, &multistore.Store{Bstore: e.opts.Blockstore}, q.PayloadCID, sel)
 	// We don't have the block we don't even reply to avoid taking bandwidth
 	// On the client side we assume no response means they don't have it

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -187,7 +187,7 @@ func (e *Exchange) FindAndRetrieve(ctx context.Context, root cid.Cid) error {
 			return res.Err
 		}
 
-		keys, err := utils.MapKeys(ctx, root, tx.Store().Loader)
+		keys, err := utils.MapLoadableKeys(ctx, root, tx.Store().Loader)
 		if err != nil {
 			return err
 		}

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -123,7 +123,7 @@ func TestSelectionStrategies(t *testing.T) {
 
 			for i := 0; i < testCase.offers; i++ {
 				go func() {
-					wq.ReceiveOffer(deal.Offer{
+					wq.PushBack(deal.Offer{
 						MinPricePerByte: abi.NewTokenAmount(int64(rand.Intn(10))),
 					})
 				}()
@@ -182,7 +182,7 @@ func BenchmarkStrategies(b *testing.B) {
 
 			for i := 0; i < 30+b.N; i++ {
 				go func() {
-					wq.ReceiveOffer(deal.Offer{
+					wq.PushBack(deal.Offer{
 						MinPricePerByte: abi.NewTokenAmount(int64(rand.Intn(10))),
 					})
 				}()
@@ -286,7 +286,7 @@ func TestExchangeE2E(t *testing.T) {
 			selected, err := tx.Triage()
 			require.NoError(t, err)
 
-			selected.Incline(sel.All())
+			selected.Exec(DealSel(sel.All()))
 
 			ref := <-tx.Ongoing()
 			require.NoError(t, err)

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -122,9 +122,8 @@ func TestSelectionStrategies(t *testing.T) {
 			wq := testCase.strategy(exec)
 
 			for i := 0; i < testCase.offers; i++ {
-				i := i
 				go func() {
-					wq.ReceiveResponse(peer.AddrInfo{ID: peer.ID(fmt.Sprintf("%d", i))}, deal.QueryResponse{
+					wq.ReceiveOffer(deal.Offer{
 						MinPricePerByte: abi.NewTokenAmount(int64(rand.Intn(10))),
 					})
 				}()
@@ -182,9 +181,8 @@ func BenchmarkStrategies(b *testing.B) {
 			wq := testCase.strategy(exec)
 
 			for i := 0; i < 30+b.N; i++ {
-				i := i
 				go func() {
-					wq.ReceiveResponse(peer.AddrInfo{ID: peer.ID(fmt.Sprintf("%d", i))}, deal.QueryResponse{
+					wq.ReceiveOffer(deal.Offer{
 						MinPricePerByte: abi.NewTokenAmount(int64(rand.Intn(10))),
 					})
 				}()

--- a/exchange/exchange_test.go
+++ b/exchange/exchange_test.go
@@ -35,7 +35,7 @@ func (te testExecutor) SetError(err error) {
 	te.err <- err
 }
 
-func (te testExecutor) Execute(o deal.Offer) TxResult {
+func (te testExecutor) Execute(o deal.Offer, p DealExecParams) TxResult {
 	err := <-te.err
 	if err != nil {
 		return TxResult{
@@ -46,12 +46,14 @@ func (te testExecutor) Execute(o deal.Offer) TxResult {
 	return TxResult{}
 }
 
-func (te testExecutor) Confirm(o deal.Offer) bool {
+func (te testExecutor) Confirm(o deal.Offer) DealExecParams {
 	select {
 	case te.conf <- o:
 	default:
 	}
-	return true
+	return DealExecParams{
+		Accepted: true,
+	}
 }
 
 func (te testExecutor) Finish(res TxResult) {
@@ -286,7 +288,7 @@ func TestExchangeE2E(t *testing.T) {
 			selected, err := tx.Triage()
 			require.NoError(t, err)
 
-			selected.Incline()
+			selected.Incline(sel.All())
 
 			ref := <-tx.Ongoing()
 			require.NoError(t, err)

--- a/exchange/index_test.go
+++ b/exchange/index_test.go
@@ -33,13 +33,13 @@ func TestIndexLFU(t *testing.T) {
 	idx, err := NewIndex(ds, bs, WithBounds(512000, 500000))
 
 	ref1 := &DataRef{
-		PayloadCID:  blockGen.Next().Cid(),
+		PayloadCID:  testutil.CreateRandomBlock(t, bs).Cid(),
 		PayloadSize: 256000,
 	}
 	require.NoError(t, idx.SetRef(ref1))
 
 	ref2 := &DataRef{
-		PayloadCID:  blockGen.Next().Cid(),
+		PayloadCID:  testutil.CreateRandomBlock(t, bs).Cid(),
 		PayloadSize: 110000,
 	}
 	require.NoError(t, idx.SetRef(ref2))
@@ -49,7 +49,7 @@ func TestIndexLFU(t *testing.T) {
 	_, err = idx.GetRef(ref2.PayloadCID)
 
 	ref3 := &DataRef{
-		PayloadCID:  blockGen.Next().Cid(),
+		PayloadCID:  testutil.CreateRandomBlock(t, bs).Cid(),
 		PayloadSize: 356000,
 	}
 	require.NoError(t, idx.SetRef(ref3))
@@ -72,13 +72,13 @@ func TestIndexLFU(t *testing.T) {
 	require.NoError(t, err)
 
 	ref4 := &DataRef{
-		PayloadCID:  blockGen.Next().Cid(),
+		PayloadCID:  testutil.CreateRandomBlock(t, bs).Cid(),
 		PayloadSize: 20000,
 	}
 	require.NoError(t, idx.SetRef(ref4))
 
 	ref5 := &DataRef{
-		PayloadCID:  blockGen.Next().Cid(),
+		PayloadCID:  testutil.CreateRandomBlock(t, bs).Cid(),
 		PayloadSize: 60000,
 	}
 	require.NoError(t, idx.SetRef(ref5))
@@ -314,7 +314,7 @@ func TestIndexListRefs(t *testing.T) {
 	// this loop sets 100 refs for 24 bytes = 2400 bytes
 	for i := 0; i < 103; i++ {
 		ref := &DataRef{
-			PayloadCID:  blockGen.Next().Cid(),
+			PayloadCID:  testutil.CreateRandomBlock(t, bs).Cid(),
 			PayloadSize: 24,
 		}
 		require.NoError(t, idx.SetRef(ref))
@@ -440,7 +440,7 @@ func TestIndexInterest(t *testing.T) {
 		// this loop sets 100 refs for 24 bytes = 2400 bytes
 		for i := 0; i < n; i++ {
 			ref := &DataRef{
-				PayloadCID:  blockGen.Next().Cid(),
+				PayloadCID:  testutil.CreateRandomBlock(t, bs).Cid(),
 				PayloadSize: 24,
 			}
 			require.NoError(t, idx.SetRef(ref))

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -400,7 +400,7 @@ func (r *Replication) handleRequest(s network.Stream) {
 
 				keys, err := utils.MapLoadableKeys(ctx, req.PayloadCID, store.Loader)
 				if err != nil {
-					log.Debug().Err(err).Msg("error when fetching keys")
+					log.Debug().Err(err).Msg("error when loading keys")
 				}
 
 				ref := &DataRef{

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -398,7 +398,7 @@ func (r *Replication) handleRequest(s network.Stream) {
 			case datatransfer.Completed:
 				store := r.GetStore(req.PayloadCID)
 
-				keys, err := utils.MapKeys(ctx, req.PayloadCID, store.Loader)
+				keys, err := utils.MapLoadableKeys(ctx, req.PayloadCID, store.Loader)
 				if err != nil {
 					log.Debug().Err(err).Msg("error when fetching keys")
 				}

--- a/exchange/routing.go
+++ b/exchange/routing.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 	"sync"
 	"time"
 
@@ -23,7 +22,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/myelnet/pop/internal/utils"
 	"github.com/myelnet/pop/retrieval/deal"
 	"github.com/rs/zerolog/log"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -109,9 +107,25 @@ func (qs *QueryStream) ReadQueryResponse() (deal.QueryResponse, error) {
 	return resp, nil
 }
 
-// WriteQueryResponse encodes and writes a CBOR QueryResponse message to a stream
+// WriteQueryResponse encodes and writes a CBOR QueryResponse message to a stream.
 func (qs *QueryStream) WriteQueryResponse(qr deal.QueryResponse) error {
 	return cborutil.WriteCborRPC(qs.rw, &qr)
+}
+
+// ReadOffer reads and decodes a CBOR encoded offer message.
+func (qs *QueryStream) ReadOffer() (deal.Offer, error) {
+	var offer deal.Offer
+
+	if err := offer.UnmarshalCBOR(qs.buf); err != nil {
+		return deal.Offer{}, err
+	}
+
+	return offer, nil
+}
+
+// WriteOffer encodes and writes an Offer message to byte stream.
+func (qs *QueryStream) WriteOffer(o deal.Offer) error {
+	return cborutil.WriteCborRPC(qs.rw, &o)
 }
 
 // Close the underlying stream
@@ -136,8 +150,11 @@ type MessageTracker interface {
 // ReceiveResponse is fired every time we get a response
 type ReceiveResponse func(peer.AddrInfo, deal.QueryResponse)
 
-// ResponseFunc takes a Query and returns a Response or an error if request is declined
-type ResponseFunc func(context.Context, peer.ID, Region, deal.Query) (deal.QueryResponse, error)
+// ReceiveOffer is a callback for receiving a new offer
+type ReceiveOffer func(deal.Offer)
+
+// ResponseFunc takes a Query and returns an Offer or an error if request is declined
+type ResponseFunc func(context.Context, peer.ID, Region, deal.Query) (deal.Offer, error)
 
 // GossipRouting is a content routing service to find content providers using pubsub gossip routing
 type GossipRouting struct {
@@ -148,7 +165,7 @@ type GossipRouting struct {
 	meta           MessageTracker
 	regions        []Region
 	rmu            sync.Mutex
-	receiveResp    ReceiveResponse
+	receiveOffer   ReceiveOffer
 }
 
 // NewGossipRouting creates a new GossipRouting service
@@ -160,7 +177,6 @@ func NewGossipRouting(h host.Host, ps *pubsub.PubSub, meta MessageTracker, rgs [
 		regions: rgs,
 		tops:    make([]*pubsub.Topic, len(rgs)),
 		queryProtocols: []protocol.ID{
-			FilQueryProtocolID,
 			PopQueryProtocolID,
 		},
 	}
@@ -169,8 +185,33 @@ func NewGossipRouting(h host.Host, ps *pubsub.PubSub, meta MessageTracker, rgs [
 
 // StartProviding opens up our gossip subscription and sets our stream handler
 func (gr *GossipRouting) StartProviding(ctx context.Context, fn ResponseFunc) error {
-	// We only need to handle the Pop query protocol since Fil is for querying storage miners
-	gr.h.SetStreamHandler(PopQueryProtocolID, gr.handleQueryResponse)
+	// The PopQueryProtocolID handler expects offer messages from peers who received a gossip query
+	gr.h.SetStreamHandler(PopQueryProtocolID, gr.handleOffer)
+
+	// The FilQueryProtocolID handler expects query messages
+	gr.h.SetStreamHandler(FilQueryProtocolID, func(s network.Stream) {
+		buffered := bufio.NewReaderSize(s, 16)
+		defer s.Close()
+
+		receivedFrom := s.Conn().RemotePeer()
+
+		m := new(deal.Query)
+		if err := m.UnmarshalCBOR(buffered); err != nil {
+			return
+		}
+		// supports single region only
+		offer, err := fn(ctx, receivedFrom, gr.regions[0], *m)
+		if err != nil {
+			return
+		}
+
+		qs := &QueryStream{p: receivedFrom, rw: s, buf: buffered}
+
+		err = qs.WriteQueryResponse(offer.AsQueryResponse())
+		if err != nil {
+			log.Error().Err(err).Msg("writing query response")
+		}
+	})
 
 	for i, r := range gr.regions {
 		top, err := gr.ps.Join(fmt.Sprintf("%s/%s", PopQueryProtocolID, r.Name))
@@ -202,21 +243,25 @@ func (gr *GossipRouting) pump(ctx context.Context, sub *pubsub.Subscription, fn 
 		if err := m.UnmarshalCBOR(bytes.NewReader(msg.Data)); err != nil {
 			continue
 		}
-		resp, err := fn(ctx, msg.ReceivedFrom, r, *m)
+		offer, err := fn(ctx, msg.ReceivedFrom, r, *m)
 		if err != nil {
 			continue
 		}
 
-		qs, err := gr.NewQueryStream(msg.ReceivedFrom)
+		qs, err := gr.NewQueryStream(msg.ReceivedFrom, gr.queryProtocols)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to create response query stream")
 			continue
 		}
-		resp.Message, err = gr.ResponseMsg(msg.Message)
-		if err != nil {
+		offer.ID = pubsub.DefaultMsgIdFn(msg.Message)
+		addrs, err := gr.Addrs()
+		if err != nil || len(addrs) == 0 {
+			log.Error().Err(err).Msg("failed to get host addresses")
 			continue
 		}
-		if err := qs.WriteQueryResponse(resp); err != nil {
+		offer.PeerAddr = addrs[0].Bytes()
+
+		if err := qs.WriteOffer(offer); err != nil {
 			log.Error().Err(err).Msg("retrieval query: WriteCborRPC")
 			continue
 		}
@@ -224,31 +269,21 @@ func (gr *GossipRouting) pump(ctx context.Context, sub *pubsub.Subscription, fn 
 	}
 }
 
-// ResponseMsg prepares the QueryResponse Message payload
-func (gr *GossipRouting) ResponseMsg(msg *pb.Message) (string, error) {
-	addrs, err := gr.Addrs()
-	if err != nil {
-		return "", err
-	}
-	mid := pubsub.DefaultMsgIdFn(msg)
-	// Our message payload includes the message ID and the recipient peer address
-	// The index indicates where to slice the string to extract both values
-	p := fmt.Sprintf("%d%s%s", len(mid), mid, string(addrs[0].Bytes()))
-	return p, nil
-}
-
-// QueryPeer asks another peer directly for retrieval conditions
-func (gr *GossipRouting) QueryPeer(p peer.AddrInfo, root cid.Cid, fn ReceiveResponse) error {
-	stream, err := gr.NewQueryStream(p.ID)
+// QueryProvider asks a provider directly for retrieval conditions
+func (gr *GossipRouting) QueryProvider(p peer.AddrInfo, root cid.Cid, sel ipld.Node, fn ReceiveOffer) error {
+	params, err := deal.NewQueryParams(sel)
 	if err != nil {
 		return err
 	}
+	m := deal.Query{
+		PayloadCID:  root,
+		QueryParams: params,
+	}
+
+	stream, err := gr.NewQueryStream(p.ID, []protocol.ID{FilQueryProtocolID})
 	defer stream.Close()
 
-	err = stream.WriteQuery(deal.Query{
-		PayloadCID:  root,
-		QueryParams: deal.QueryParams{}, // Filecoin does not support selectors in queries yet
-	})
+	err = stream.WriteQuery(m)
 	if err != nil {
 		return err
 	}
@@ -257,7 +292,20 @@ func (gr *GossipRouting) QueryPeer(p peer.AddrInfo, root cid.Cid, fn ReceiveResp
 	if err != nil {
 		return err
 	}
-	fn(p, res)
+	addrs, err := peer.AddrInfoToP2pAddrs(&p)
+	if err != nil {
+		return err
+	}
+	fn(deal.Offer{
+		PeerAddr:                   addrs[0].Bytes(),
+		PayloadCID:                 root,
+		Size:                       res.Size,
+		PaymentAddress:             res.PaymentAddress,
+		MinPricePerByte:            res.MinPricePerByte,
+		MaxPaymentInterval:         res.MaxPaymentInterval,
+		MaxPaymentIntervalIncrease: res.MaxPaymentIntervalIncrease,
+		UnsealPrice:                res.UnsealPrice,
+	})
 	return nil
 }
 
@@ -289,16 +337,16 @@ func (gr *GossipRouting) Query(ctx context.Context, root cid.Cid, sel ipld.Node)
 	return nil
 }
 
-// SetReceiver sets a callback to receive discovery responses
-func (gr *GossipRouting) SetReceiver(fn ReceiveResponse) {
+// SetReceiver sets a callback to receive offers from gossip routers
+func (gr *GossipRouting) SetReceiver(fn ReceiveOffer) {
 	gr.rmu.Lock()
-	gr.receiveResp = fn
+	gr.receiveOffer = fn
 	gr.rmu.Unlock()
 }
 
 // NewQueryStream creates a new query stream using the provided peer.ID to handle the Query protocols
-func (gr *GossipRouting) NewQueryStream(dest peer.ID) (*QueryStream, error) {
-	s, err := OpenStream(context.Background(), gr.h, dest, gr.queryProtocols)
+func (gr *GossipRouting) NewQueryStream(dest peer.ID, protos []protocol.ID) (*QueryStream, error) {
+	s, err := OpenStream(context.Background(), gr.h, dest, protos)
 	if err != nil {
 		return nil, err
 	}
@@ -306,49 +354,23 @@ func (gr *GossipRouting) NewQueryStream(dest peer.ID) (*QueryStream, error) {
 	return &QueryStream{p: dest, rw: s, buf: buffered}, nil
 }
 
-// handleQueryResponse reads a QueryResponse message from an incoming stream, reads the Message
-// if a message is provided, it parses the ID embedded in it and checks if the reference matches
-// one we published. If we did publish it means we are expecting the response to we read the response
-// and send it to the receiver if not and we have a sender for the message reference we forward it back
-// if there is no message attached with the response it might be sent from a Filecoin storage miner so
-// we still try to send it to the receiver.
-func (gr *GossipRouting) handleQueryResponse(s network.Stream) {
+// handleOffer reads an Offer message from an incoming stream, and checks if it matches
+// any query we published. If we did publish it means we are expecting responses so we read the offer
+// and send it to the receiver if not and we have a sender for the message reference we forward it back.
+func (gr *GossipRouting) handleOffer(s network.Stream) {
 	buffered := bufio.NewReaderSize(s, 16)
 	defer s.Close()
 
 	buf := new(bytes.Buffer)
-	msg, err := PeekResponseMsg(buffered, buf)
+	id, err := PeekOfferID(buffered, buf)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to peek message")
+		log.Error().Err(err).Msg("failed to peek offer ID")
 		return
 	}
-	// Here we handle messages from Filecoin miners
-	if len(msg) == 0 {
-		gr.rmu.Lock()
-		defer gr.rmu.Unlock()
-		if gr.receiveResp == nil {
-			log.Error().Msg("received resp")
-			return
-		}
-		var resp deal.QueryResponse
-		if err := resp.UnmarshalCBOR(buf); err != nil && !errors.Is(err, io.EOF) {
-			log.Error().Err(err).Msg("failed to read query response")
-			return
-		}
-		gr.receiveResp(gr.h.Peerstore().PeerInfo(s.Conn().RemotePeer()), resp)
-		return
-	}
-	// Get the index where to split
-	is, err := strconv.ParseInt(msg[:2], 10, 64)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to parse index")
-		return
-	}
-	msgID := msg[2 : is+2]
 	// The receiver should know if we issued the query if it's not the case
 	// it means we must forward it to whichever peer sent us the query
-	if !gr.meta.Published(msgID) {
-		to, err := gr.meta.Sender(msgID)
+	if !gr.meta.Published(id) {
+		to, err := gr.meta.Sender(id)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to find message recipient")
 			return
@@ -366,23 +388,17 @@ func (gr *GossipRouting) handleQueryResponse(s network.Stream) {
 	gr.rmu.Lock()
 	defer gr.rmu.Unlock()
 	// Stop if we don't have a receiver set
-	if gr.receiveResp == nil {
+	if gr.receiveOffer == nil {
 		return
 	}
 
-	rec, err := utils.AddrBytesToAddrInfo([]byte(msg[is+2:]))
-	if err != nil {
-		log.Error().Err(err).Msg("failed to parse addr bytes")
+	var offer deal.Offer
+	if err := offer.UnmarshalCBOR(buf); err != nil && !errors.Is(err, io.EOF) {
+		log.Error().Err(err).Msg("failed to read offer")
 		return
 	}
 
-	var resp deal.QueryResponse
-	if err := resp.UnmarshalCBOR(buf); err != nil && !errors.Is(err, io.EOF) {
-		log.Error().Err(err).Msg("failed to read query response")
-		return
-	}
-
-	gr.receiveResp(*rec, resp)
+	gr.receiveOffer(offer)
 }
 
 // Addrs returns the host's p2p addresses
@@ -395,8 +411,8 @@ func (gr *GossipRouting) AddAddrs(p peer.ID, addrs []ma.Multiaddr) {
 	gr.h.Peerstore().AddAddrs(p, addrs, 8*time.Hour)
 }
 
-// PeekResponseMsg decodes the Message field only and returns the value while copying the bytes in a buffer
-func PeekResponseMsg(r io.Reader, buf *bytes.Buffer) (string, error) {
+// PeekOfferID decodes the ID field only and returns the value while copying the bytes in a buffer
+func PeekOfferID(r io.Reader, buf *bytes.Buffer) (string, error) {
 	tr := io.TeeReader(r, buf)
 	br := cbg.GetPeeker(tr)
 	scratch := make([]byte, 8)
@@ -414,7 +430,7 @@ func PeekResponseMsg(r io.Reader, buf *bytes.Buffer) (string, error) {
 			}
 			name = string(sval)
 		}
-		if name == "Message" {
+		if name == "ID" {
 			sval, err := cbg.ReadStringBuf(br, scratch)
 			if err != nil {
 				return "", err

--- a/exchange/tx_test.go
+++ b/exchange/tx_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-multistore"
+	"github.com/ipfs/go-cid"
 	files "github.com/ipfs/go-ipfs-files"
 	"github.com/ipfs/go-path"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -492,4 +493,9 @@ loop:
 	entries, err := gtx.Entries()
 	require.NoError(t, err)
 	require.Equal(t, len(filepaths)+1, len(entries))
+
+	// We can access the root of an entry to fetch individually
+	eroot, err := gtx.RootFor("line8.txt")
+	require.NoError(t, err)
+	require.Equal(t, uint64(cid.Raw), eroot.Type())
 }

--- a/exchange/tx_test.go
+++ b/exchange/tx_test.go
@@ -483,13 +483,12 @@ loop:
 		}
 	}
 
-	// @NOTE: even when selecting a specific key the operation will retrieve all other the entries
-	// without the linked data. We may need to alter this behavior in cases where there is a large
-	// number of entries
+	// @NOTE: Keys() returns the keys for the entries for which the linked data is actually available
 	keys, err = gtx.Keys()
 	require.NoError(t, err)
-	require.Equal(t, len(filepaths)+1, len(keys))
+	require.Equal(t, 0, len(keys))
 
+	// Entries returns all the entries regardless of if the links are loadable
 	entries, err := gtx.Entries()
 	require.NoError(t, err)
 	require.Equal(t, len(filepaths)+1, len(entries))

--- a/exchange/tx_test.go
+++ b/exchange/tx_test.go
@@ -315,7 +315,9 @@ func TestMapFieldSelector(t *testing.T) {
 
 	// We skip discovery and request an offer directly
 	info := host.InfoFromHost(n1.Host)
-	require.NoError(t, gtx.QueryFrom(*info, sel.Key(key)))
+	offer, err := gtx.QueryOffer(*info, sel.Key(key))
+	require.NoError(t, err)
+	gtx.ApplyOffer(offer)
 
 loop:
 	for {

--- a/go.mod
+++ b/go.mod
@@ -81,3 +81,5 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
+
+replace github.com/filecoin-project/go-data-transfer => ../go-data-transfer

--- a/go.mod
+++ b/go.mod
@@ -81,5 +81,3 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
-
-replace github.com/filecoin-project/go-data-transfer => ../go-data-transfer

--- a/node/message.go
+++ b/node/message.go
@@ -176,7 +176,7 @@ type GetResult struct {
 	TotalSpent      string  `json:"totalSpent,omitempty"`
 	TotalReceived   int64   `json:"totalReceived,omitempty"`
 	BytesPaidFor    string  `json:"bytesPaidFor,omitempty"`
-	TotalPrice      string  `json:"totalPrice,omitempty"`
+	TotalFunds      string  `json:"totalFunds,omitempty"`
 	PricePerByte    string  `json:"pricePerByte,omitempty"`
 	UnsealPrice     string  `json:"unsealPrice,omitempty"`
 	DiscLatSeconds  float64 `json:"discLatSeconds,omitempty"`

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -69,6 +69,7 @@ func newTestNode(ctx context.Context, mn mocknet.Mocknet, t *testing.T) *node {
 	nd.ms = tn.Ms
 	nd.dag = tn.DAG
 	nd.host = tn.Host
+	nd.omg = NewOfferMgr()
 	opts := exchange.Options{
 		Blockstore:  nd.bs,
 		MultiStore:  nd.ms,
@@ -741,7 +742,192 @@ func TestImportKey(t *testing.T) {
 // Preload is a full integration test for gradually retrieving a DAG paid with a single
 // payment channel
 func TestPreload(t *testing.T) {
-	var blockGen = blocksutil.NewBlockGenerator()
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	mn := mocknet.New(ctx)
+
+	region := exchange.Regions["Europe"]
+
+	// Provider setup
+	tn1 := testutil.NewTestNode(mn, t)
+	pn := &node{}
+	pn.ds = tn1.Ds
+	pn.bs = tn1.Bs
+	pn.ms = tn1.Ms
+	pn.dag = tn1.DAG
+	pn.host = tn1.Host
+	pfapi := filecoin.NewMockLotusAPI()
+	popts := exchange.Options{
+		Blockstore:  pn.bs,
+		MultiStore:  pn.ms,
+		RepoPath:    t.TempDir(),
+		Regions:     []exchange.Region{region},
+		FilecoinAPI: pfapi,
+	}
+	popts.Wallet = wallet.NewFromKeystore(keystore.NewMemKeystore(), wallet.WithFilAPI(popts.FilecoinAPI))
+	pn.exch, err = exchange.New(ctx, pn.host, pn.ds, popts)
+	require.NoError(t, err)
+
+	// Client setup
+	tn2 := testutil.NewTestNode(mn, t)
+	cn := &node{}
+	cn.ds = tn2.Ds
+	cn.bs = tn2.Bs
+	cn.ms = tn2.Ms
+	cn.dag = tn2.DAG
+	cn.host = tn2.Host
+	cn.omg = NewOfferMgr()
+	cfapi := filecoin.NewMockLotusAPI()
+	copts := exchange.Options{
+		Blockstore:  cn.bs,
+		MultiStore:  cn.ms,
+		RepoPath:    t.TempDir(),
+		Regions:     []exchange.Region{region},
+		FilecoinAPI: cfapi,
+	}
+	copts.Wallet = wallet.NewFromKeystore(keystore.NewMemKeystore(), wallet.WithFilAPI(copts.FilecoinAPI))
+	cn.exch, err = exchange.New(ctx, cn.host, cn.ds, copts)
+	require.NoError(t, err)
+
+	require.NoError(t, mn.LinkAll())
+	require.NoError(t, mn.ConnectAllButSelf())
+
+	// Let the routing propagate to gossip
+	time.Sleep(time.Second)
+
+	tx := pn.exch.Tx(ctx)
+
+	data1 := make([]byte, 10000)
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(data1)
+	cid1, err := pn.Add(ctx, tx.Store().DAG, bytes.NewReader(data1))
+	require.NoError(t, err)
+	require.NoError(t, tx.Put("first", cid1, 10000))
+
+	data2 := make([]byte, 14000)
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(data2)
+	cid2, err := pn.Add(ctx, tx.Store().DAG, bytes.NewReader(data2))
+	require.NoError(t, err)
+	require.NoError(t, tx.Put("second", cid2, 14000))
+
+	data3 := make([]byte, 26000)
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(data3)
+	cid3, err := pn.Add(ctx, tx.Store().DAG, bytes.NewReader(data3))
+	require.NoError(t, err)
+	require.NoError(t, tx.Put("third", cid3, 26000))
+
+	tx.SetCacheRF(0)
+	require.NoError(t, tx.Commit())
+	ref := tx.Ref()
+	root := ref.PayloadCID
+	require.NoError(t, pn.exch.Index().SetRef(ref))
+	require.NoError(t, tx.Close())
+
+	var chAddr address.Address
+
+	results, err := cn.Load(ctx, &GetArgs{Cid: root.String()})
+	require.NoError(t, err)
+
+	// Discovery went well, we got an offer
+	select {
+	case res := <-results:
+		require.Equal(t, "DealStatusSelectedOffer", res.Status)
+
+		// Prepare the payment channel mocks
+		from := cn.exch.Wallet().DefaultAddress()
+
+		price, err := filecoin.ParseFIL(res.TotalPrice)
+		require.NoError(t, err)
+
+		createAmt := big.NewFromGo(price.Int)
+		chAddr = prepChannel(t, from, cfapi, pfapi, createAmt)
+
+	case <-ctx.Done():
+		t.Fatal("could not select an offer")
+	}
+
+	// Deal started correctly, we have a deal ID
+	select {
+	case res := <-results:
+		require.NotEqual(t, "", res.DealID)
+	case <-ctx.Done():
+		t.Fatal("could not start the transfer")
+	}
+
+	lookup := testutil.FormatMsgLookup(t, chAddr)
+	cfapi.SetMsgLookup(lookup)
+
+loop:
+	for {
+		select {
+		case res := <-results:
+			if res.Status == "Completed" {
+				break loop
+			}
+			require.Equal(t, "", res.Err)
+		case <-ctx.Done():
+			t.Fatal("could not complete transfer")
+		}
+	}
+
+	// We should have a single channel
+	channels, err := cn.exch.Payments().ListChannels()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(channels))
+
+	// Check if the ref is here
+	ref, err = cn.exch.Index().GetRef(root)
+	require.NoError(t, err)
+	require.Equal(t, false, ref.Has("first"))
+
+	// from now on we should have the funds to retrieve everything progressively
+	// from the same peer using the same payment channel
+	results = make(chan GetResult)
+	go func() {
+		for res := range results {
+			require.Equal(t, "", res.Err)
+		}
+	}()
+
+	err = cn.get(ctx, root, &GetArgs{Key: "first", Strategy: "SelectFirst"}, results)
+	require.NoError(t, err)
+
+	// We should still have a single channel
+	channels, err = cn.exch.Payments().ListChannels()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(channels))
+
+	results = make(chan GetResult)
+	go func() {
+		for res := range results {
+			require.Equal(t, "", res.Err)
+		}
+	}()
+	err = cn.get(ctx, root, &GetArgs{Key: "second", Strategy: "SelectFirst"}, results)
+	require.NoError(t, err)
+
+	// We should still have a single channel
+	channels, err = cn.exch.Payments().ListChannels()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(channels))
+
+	results = make(chan GetResult)
+	go func() {
+		for res := range results {
+			require.Equal(t, "", res.Err)
+		}
+	}()
+	err = cn.get(ctx, root, &GetArgs{Key: "third", Strategy: "SelectFirst"}, results)
+	require.NoError(t, err)
+
+	// We should still have a single channel
+	channels, err = cn.exch.Payments().ListChannels()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(channels))
+}
+
+// LoadKey tests loading a single key in a transaction
+func TestLoadKey(t *testing.T) {
 	var err error
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -825,20 +1011,217 @@ func TestPreload(t *testing.T) {
 
 	// Prepare the payment channel mocks
 	from := cn.exch.Wallet().DefaultAddress()
+	var chAddr address.Address
 	// to := pn.exch.Wallet().DefaultAddress()
 
+	results, err := cn.Load(ctx, &GetArgs{Cid: root.String(), Key: "second"})
+	require.NoError(t, err)
+
+	// Discovery went well, we got an offer
+	select {
+	case res := <-results:
+		require.Equal(t, "DealStatusSelectedOffer", res.Status)
+
+		price, err := filecoin.ParseFIL(res.TotalPrice)
+		require.NoError(t, err)
+
+		createAmt := big.NewFromGo(price.Int)
+
+		chAddr = prepChannel(t, from, cfapi, pfapi, createAmt)
+	case <-ctx.Done():
+		t.Fatal("could not select an offer")
+	}
+
+	// Deal started correctly, we have a deal ID
+	select {
+	case res := <-results:
+		require.NotEqual(t, "", res.DealID)
+	case <-ctx.Done():
+		t.Fatal("could not start the transfer")
+	}
+
+	lookup := testutil.FormatMsgLookup(t, chAddr)
+	cfapi.SetMsgLookup(lookup)
+
+loop:
+	for {
+		select {
+		case res := <-results:
+			if res.Status == "Completed" {
+				break loop
+			}
+			require.Equal(t, "", res.Err)
+		case <-ctx.Done():
+			t.Fatal("could not complete transfer")
+		}
+	}
+
+	// We should have a single channel
+	channels, err := cn.exch.Payments().ListChannels()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(channels))
+
+	// Check if the ref is here
+	ref, err = cn.exch.Index().GetRef(root)
+	require.NoError(t, err)
+	require.Equal(t, true, ref.Has("second"))
+}
+
+// LoadAll tests loading all the content from a transaction
+func TestLoadAll(t *testing.T) {
+	var err error
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	mn := mocknet.New(ctx)
+
+	region := exchange.Regions["Europe"]
+
+	// Provider setup
+	tn1 := testutil.NewTestNode(mn, t)
+	pn := &node{}
+	pn.ds = tn1.Ds
+	pn.bs = tn1.Bs
+	pn.ms = tn1.Ms
+	pn.dag = tn1.DAG
+	pn.host = tn1.Host
+	pfapi := filecoin.NewMockLotusAPI()
+	popts := exchange.Options{
+		Blockstore:  pn.bs,
+		MultiStore:  pn.ms,
+		RepoPath:    t.TempDir(),
+		Regions:     []exchange.Region{region},
+		FilecoinAPI: pfapi,
+	}
+	popts.Wallet = wallet.NewFromKeystore(keystore.NewMemKeystore(), wallet.WithFilAPI(popts.FilecoinAPI))
+	pn.exch, err = exchange.New(ctx, pn.host, pn.ds, popts)
+	require.NoError(t, err)
+
+	// Client setup
+	tn2 := testutil.NewTestNode(mn, t)
+	cn := &node{}
+	cn.ds = tn2.Ds
+	cn.bs = tn2.Bs
+	cn.ms = tn2.Ms
+	cn.dag = tn2.DAG
+	cn.host = tn2.Host
+	cn.omg = NewOfferMgr()
+	cfapi := filecoin.NewMockLotusAPI()
+	copts := exchange.Options{
+		Blockstore:  cn.bs,
+		MultiStore:  cn.ms,
+		RepoPath:    t.TempDir(),
+		Regions:     []exchange.Region{region},
+		FilecoinAPI: cfapi,
+	}
+	copts.Wallet = wallet.NewFromKeystore(keystore.NewMemKeystore(), wallet.WithFilAPI(copts.FilecoinAPI))
+	cn.exch, err = exchange.New(ctx, cn.host, cn.ds, copts)
+	require.NoError(t, err)
+
+	require.NoError(t, mn.LinkAll())
+	require.NoError(t, mn.ConnectAllButSelf())
+
+	// Let the routing propagate to gossip
+	time.Sleep(time.Second)
+
+	tx := pn.exch.Tx(ctx)
+
+	data1 := make([]byte, 10000)
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(data1)
+	cid1, err := pn.Add(ctx, tx.Store().DAG, bytes.NewReader(data1))
+	require.NoError(t, err)
+	require.NoError(t, tx.Put("first", cid1, 10000))
+
+	data2 := make([]byte, 14000)
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(data2)
+	cid2, err := pn.Add(ctx, tx.Store().DAG, bytes.NewReader(data2))
+	require.NoError(t, err)
+	require.NoError(t, tx.Put("second", cid2, 14000))
+
+	data3 := make([]byte, 26000)
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(data3)
+	cid3, err := pn.Add(ctx, tx.Store().DAG, bytes.NewReader(data3))
+	require.NoError(t, err)
+	require.NoError(t, tx.Put("third", cid3, 26000))
+
+	tx.SetCacheRF(0)
+	require.NoError(t, tx.Commit())
+	ref := tx.Ref()
+	root := ref.PayloadCID
+	require.NoError(t, pn.exch.Index().SetRef(ref))
+	require.NoError(t, tx.Close())
+
+	// Prepare the payment channel mocks
+	from := cn.exch.Wallet().DefaultAddress()
+	var chAddr address.Address
+
+	results, err := cn.Load(ctx, &GetArgs{Cid: root.String(), Key: "*"})
+	require.NoError(t, err)
+
+	// Discovery went well, we got an offer
+	select {
+	case res := <-results:
+		require.Equal(t, "DealStatusSelectedOffer", res.Status)
+
+		price, err := filecoin.ParseFIL(res.TotalPrice)
+		require.NoError(t, err)
+
+		createAmt := big.NewFromGo(price.Int)
+
+		chAddr = prepChannel(t, from, cfapi, pfapi, createAmt)
+	case <-ctx.Done():
+		t.Fatal("could not select an offer")
+	}
+
+	// Deal started correctly, we have a deal ID
+	select {
+	case res := <-results:
+		require.NotEqual(t, "", res.DealID)
+	case <-ctx.Done():
+		t.Fatal("could not start the transfer")
+	}
+
+	lookup := testutil.FormatMsgLookup(t, chAddr)
+	cfapi.SetMsgLookup(lookup)
+
+loop:
+	for {
+		select {
+		case res := <-results:
+			if res.Status == "Completed" {
+				break loop
+			}
+			require.Equal(t, "", res.Err)
+		case <-ctx.Done():
+			t.Fatal("could not complete transfer")
+		}
+	}
+
+	// We should have a single channel
+	channels, err := cn.exch.Payments().ListChannels()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(channels))
+
+	// Check if the ref is here
+	ref, err = cn.exch.Index().GetRef(root)
+	require.NoError(t, err)
+	require.Equal(t, true, ref.Has("first"))
+	require.Equal(t, true, ref.Has("second"))
+	require.Equal(t, true, ref.Has("third"))
+}
+
+func prepChannel(t *testing.T, from address.Address, c, p *filecoin.MockLotusAPI, createAmt big.Int) address.Address {
+	var blockGen = blocksutil.NewBlockGenerator()
 	payerAddr := tutils.NewIDAddr(t, 102)
 	payeeAddr := tutils.NewIDAddr(t, 103)
 
-	createAmt := big.Mul(region.PPB, abi.NewTokenAmount(ref.PayloadSize))
 	act := &filecoin.Actor{
 		Code:    blockGen.Next().Cid(),
 		Head:    blockGen.Next().Cid(),
 		Nonce:   1,
 		Balance: createAmt,
 	}
-	cfapi.SetActor(act)
-	pfapi.SetActor(act)
+	c.SetActor(act)
+	p.SetActor(act)
 
 	chAddr := tutils.NewIDAddr(t, 101)
 	initActorAddr := tutils.NewIDAddr(t, 100)
@@ -867,162 +1250,27 @@ func TestPreload(t *testing.T) {
 	}
 	// We need to set an actor state as creating a voucher will query the state from the chain
 	// both apis are sharing the same state
-	cfapi.SetActorState(&actState)
-	pfapi.SetActorState(&actState)
+	c.SetActorState(&actState)
+	p.SetActorState(&actState)
 	// See channel tests for note about this
 	objReader := func(c cid.Cid) []byte {
 		var bg testutil.BytesGetter
 		rt.StoreGet(c, &bg)
 		return bg.Bytes()
 	}
-	cfapi.SetObjectReader(objReader)
-	pfapi.SetObjectReader(objReader)
+	c.SetObjectReader(objReader)
+	p.SetObjectReader(objReader)
 
-	cfapi.SetAccountKey(from)
+	c.SetAccountKey(from)
 	// provider is resolving the account key to verify the voucher signature
-	pfapi.SetAccountKey(from)
+	p.SetAccountKey(from)
 
 	// Return success exit code from calls to check if voucher is spendable
-	pfapi.SetInvocResult(&filecoin.InvocResult{
+	p.SetInvocResult(&filecoin.InvocResult{
 		MsgRct: &filecoin.MessageReceipt{
 			ExitCode: 0,
 		},
 	})
 
-	results, err := cn.PreloadEntries(ctx, &GetArgs{Cid: root.String()})
-	require.NoError(t, err)
-
-	// Discovery went well, we got an offer
-	select {
-	case res := <-results:
-		require.Equal(t, "DealStatusSelectedOffer", res.Status)
-	case <-ctx.Done():
-		t.Fatal("could not select an offer")
-	}
-
-	// Deal started correctly, we have a deal ID
-	select {
-	case res := <-results:
-		require.NotEqual(t, "", res.DealID)
-	case <-ctx.Done():
-		t.Fatal("could not start the transfer")
-	}
-
-	lookup := testutil.FormatMsgLookup(t, chAddr)
-	cfapi.SetMsgLookup(lookup)
-
-loop:
-	for {
-		select {
-		case res := <-results:
-			if res.Status == "DealStatusCompleted" {
-				break loop
-			}
-			if res.Err != "" {
-				t.Error(res.Err)
-			}
-		case <-ctx.Done():
-			t.Fatal("could not complete transfer")
-		}
-	}
-
-	// We should have a single channel
-	channels, err := cn.exch.Payments().ListChannels()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(channels))
-
-	// from now on we should have the funds to retrieve everything progressively
-	// from the same peer using the same payment channel
-	results, err = cn.Load(ctx, &GetArgs{Cid: fmt.Sprintf("%v/%s", root, "first")})
-	require.NoError(t, err)
-
-	// Deal started correctly, we have a deal ID
-	select {
-	case res := <-results:
-		require.NotEqual(t, "", res.DealID)
-	case <-ctx.Done():
-		t.Fatal("could not start the transfer")
-	}
-
-loop2:
-	for {
-		select {
-		case res := <-results:
-			if res.Status == "DealStatusCompleted" {
-				break loop2
-			}
-			if res.Err != "" {
-				t.Error(res.Err)
-			}
-		case <-ctx.Done():
-			t.Fatal("could not complete transfer")
-		}
-	}
-
-	// We should still have a single channel
-	channels, err = cn.exch.Payments().ListChannels()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(channels))
-
-	results, err = cn.Load(ctx, &GetArgs{Cid: fmt.Sprintf("%v/%s", root, "second")})
-	require.NoError(t, err)
-
-	// Deal started correctly, we have a deal ID
-	select {
-	case res := <-results:
-		require.NotEqual(t, "", res.DealID)
-	case <-ctx.Done():
-		t.Fatal("could not start the transfer")
-	}
-
-loop3:
-	for {
-		select {
-		case res := <-results:
-			if res.Status == "DealStatusCompleted" {
-				break loop3
-			}
-			if res.Err != "" {
-				t.Error(res.Err)
-			}
-		case <-ctx.Done():
-			t.Fatal("could not complete transfer")
-		}
-	}
-
-	// We should still have a single channel
-	channels, err = cn.exch.Payments().ListChannels()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(channels))
-
-	results, err = cn.Load(ctx, &GetArgs{Cid: fmt.Sprintf("%v/%s", root, "third")})
-	require.NoError(t, err)
-
-	// Deal started correctly, we have a deal ID
-	select {
-	case res := <-results:
-		require.NotEqual(t, "", res.DealID)
-	case <-ctx.Done():
-		t.Fatal("could not start the transfer")
-	}
-
-loop4:
-	for {
-		select {
-		case res := <-results:
-			if res.Status == "DealStatusCompleted" {
-				break loop4
-			}
-			if res.Err != "" {
-				t.Error(res.Err)
-			}
-		case <-ctx.Done():
-			t.Fatal("could not complete transfer")
-		}
-	}
-
-	// We should still have a single channel
-	channels, err = cn.exch.Payments().ListChannels()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(channels))
+	return chAddr
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -873,6 +873,10 @@ loop:
 	channels, err = cn.exch.Payments().ListChannels()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(channels))
+
+	// We retrieved all the keys so the offer should be removed
+	_, err = cn.omg.GetOffer(root)
+	require.Error(t, err)
 }
 
 // LoadKey tests loading a single key in a transaction

--- a/node/offermgr.go
+++ b/node/offermgr.go
@@ -1,0 +1,46 @@
+package node
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/ipfs/go-cid"
+	"github.com/myelnet/pop/retrieval/deal"
+)
+
+// OfferMgr keeps track of offers so we can reuse existing connections
+// and payment channels with peers
+type OfferMgr struct {
+	mu     sync.Mutex
+	offers map[cid.Cid]deal.Offer
+}
+
+// NewOfferMgr makes a new inmemory offer store
+func NewOfferMgr() *OfferMgr {
+	return &OfferMgr{
+		offers: make(map[cid.Cid]deal.Offer),
+	}
+}
+
+// SetOffer stores a retrieval provider's offer for a given root CID.
+// it currently assumes the Offer is valid for the entire DAG.
+func (omg *OfferMgr) SetOffer(k cid.Cid, o deal.Offer) error {
+	omg.mu.Lock()
+	defer omg.mu.Unlock()
+
+	omg.offers[k] = o
+	return nil
+}
+
+// GetOffer returns a valid offer for a given root CID if we have queries about it before
+func (omg *OfferMgr) GetOffer(k cid.Cid) (deal.Offer, error) {
+	omg.mu.Lock()
+	defer omg.mu.Unlock()
+
+	o, ok := omg.offers[k]
+	if !ok {
+		return deal.Offer{}, errors.New("no existing offer")
+	}
+
+	return o, nil
+}

--- a/node/offermgr.go
+++ b/node/offermgr.go
@@ -44,3 +44,17 @@ func (omg *OfferMgr) GetOffer(k cid.Cid) (deal.Offer, error) {
 
 	return o, nil
 }
+
+// RemoveOffer clears the offer for a given root CID for example if the offer is expired
+func (omg *OfferMgr) RemoveOffer(k cid.Cid) error {
+	omg.mu.Lock()
+	defer omg.mu.Unlock()
+
+	_, ok := omg.offers[k]
+	if !ok {
+		return errors.New("no existing offer")
+	}
+
+	delete(omg.offers, k)
+	return nil
+}

--- a/node/popn.go
+++ b/node/popn.go
@@ -1125,6 +1125,8 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 				return
 			}
 
+			log.Info().Msg("set ref")
+
 			end := time.Now()
 			transDuration := end.Sub(start) - discDuration
 
@@ -1135,6 +1137,7 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 				TransLatSeconds: transDuration.Seconds(),
 			}:
 			default:
+				log.Info().Msg("could not send completed msg")
 			}
 
 			if res.PayCh != address.Undef {
@@ -1161,6 +1164,7 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 					}
 				}
 			}
+			log.Info().Msg("return")
 			return
 		case <-ctx.Done():
 			return

--- a/node/popn.go
+++ b/node/popn.go
@@ -1113,6 +1113,20 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 				}
 			}
 
+			if res.PayCh != address.Undef {
+				leftover, err := nd.exch.Payments().ChannelAvailableFunds(res.PayCh)
+				if err != nil {
+					log.Error().Err(err).Msg("checking available funds")
+				}
+				leftAmt := big.Sub(leftover.ConfirmedAmt, leftover.VoucherRedeemedAmt)
+				if leftAmt.IsZero() {
+					err := nd.omg.RemoveOffer(root)
+					if err != nil {
+						log.Error().Err(err).Msg("removing offer")
+					}
+				}
+			}
+
 			ref := tx.Ref()
 			err = nd.exch.Index().SetRef(tx.Ref())
 			if err == exchange.ErrRefAlreadyExists {

--- a/node/popn.go
+++ b/node/popn.go
@@ -1125,8 +1125,6 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 				return
 			}
 
-			log.Info().Msg("set ref")
-
 			end := time.Now()
 			transDuration := end.Sub(start) - discDuration
 
@@ -1136,8 +1134,9 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 				DiscLatSeconds:  discDuration.Seconds(),
 				TransLatSeconds: transDuration.Seconds(),
 			}:
-			default:
-				log.Info().Msg("could not send completed msg")
+			case <-ctx.Done():
+				sendErr(ctx.Err())
+				return
 			}
 
 			if res.PayCh != address.Undef {
@@ -1164,7 +1163,6 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 					}
 				}
 			}
-			log.Info().Msg("return")
 			return
 		case <-ctx.Done():
 			return

--- a/node/popn.go
+++ b/node/popn.go
@@ -840,12 +840,12 @@ func (nd *node) Get(ctx context.Context, args *GetArgs) {
 	// Check if we're trying to get from an ongoing transaction
 	nd.txmu.Lock()
 	if nd.tx != nil && nd.tx.Root() == root {
-		f, err := nd.tx.GetFile(segs[0])
-		if err != nil {
-			sendErr(err)
-			return
-		}
 		if args.Out != "" {
+			f, err := nd.tx.GetFile(segs[0])
+			if err != nil {
+				sendErr(err)
+				return
+			}
 			err = files.WriteTo(f, args.Out)
 			if err != nil {
 				sendErr(err)
@@ -863,224 +863,43 @@ func (nd *node) Get(ctx context.Context, args *GetArgs) {
 
 	// Only support a single segment for now
 	args.Key = segs[0]
-	// Log progress
-	if args.Verbose {
-		unsub := nd.exch.Retrieval().Client().SubscribeToEvents(
-			func(event client.Event, state deal.ClientState) {
-				log.Info().
-					Str("event", client.Events[event]).
-					Str("status", deal.Statuses[state.Status]).
-					Uint64("bytes received", state.TotalReceived).
-					Msg("Retrieving")
-			},
-		)
-		defer unsub()
-	}
-	results := make(chan GetResult)
-	go func() {
-		for res := range results {
-			nd.send(Notify{
-				GetResult: &res,
-			})
-		}
-	}()
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(args.Timeout)*time.Minute)
-	defer cancel()
-	err = nd.get(ctx, root, args, results)
-	if err != nil {
-		sendErr(err)
-	}
-	close(results)
-}
 
-// get is a synchronous content retrieval operation which can be called by a CLI request or HTTP
-func (nd *node) get(ctx context.Context, c cid.Cid, args *GetArgs, results chan<- GetResult) error {
-	// Check our supply if we may already have it
-	tx := nd.exch.Tx(ctx, exchange.WithRoot(c))
+	// Check our supply if we may already have it from a different tx
+	tx := nd.exch.Tx(ctx, exchange.WithRoot(root))
 	local := tx.IsLocal(args.Key)
-	if local && args.Out != "" {
+	if !local {
+		// The content is not available locally so we must load it
+		results, err := nd.Load(ctx, args)
+		if err != nil {
+			sendErr(err)
+			return
+		}
+		for res := range results {
+			if args.Verbose || res.Status != "" {
+				nd.send(Notify{
+					GetResult: &res,
+				})
+			}
+		}
+	} else {
+		nd.send(Notify{
+			GetResult: &GetResult{
+				Local: local,
+			},
+		})
+	}
+
+	if args.Out != "" {
 		f, err := tx.GetFile(args.Key)
 		if err != nil {
-			return err
+			sendErr(err)
+			return
 		}
 		err = files.WriteTo(f, args.Out)
 		if err != nil {
-			return err
+			sendErr(err)
+			return
 		}
-	}
-	if local {
-		log.Info().Msg("content is available locally")
-		results <- GetResult{
-			Local: true,
-		}
-		return nil
-	}
-
-	var strategy exchange.SelectionStrategy
-	switch args.Strategy {
-	case "SelectFirst":
-		strategy = exchange.SelectFirst
-	case "SelectCheapest":
-		strategy = exchange.SelectCheapest(5, 4*time.Second)
-	case "SelectFirstLowerThan":
-		strategy = exchange.SelectFirstLowerThan(abi.NewTokenAmount(args.MaxPPB))
-	default:
-		return errors.New("unknown strategy")
-	}
-
-	var sl ipld.Node
-	if args.Key != "" {
-		sl = sel.Key(args.Key)
-	} else {
-		sl = sel.All()
-	}
-	start := time.Now()
-
-	// If we already have an offer we can skip routing queries
-	offer, err := nd.omg.GetOffer(c)
-	if err != nil {
-
-		tx = nd.exch.Tx(ctx, exchange.WithRoot(c), exchange.WithStrategy(strategy), exchange.WithTriage())
-		defer tx.Close()
-
-		log.Info().Msg("starting query")
-
-		if err := tx.Query(sl); err != nil {
-			return err
-		}
-		// We can query a specific miner on top of gossip
-		// that offer will be at the top of the list if we receive it
-		if args.Miner != "" {
-			miner, err := address.NewFromString(args.Miner)
-			if err != nil {
-				return err
-			}
-			info, err := nd.rs.PeerInfo(ctx, miner)
-			if err != nil {
-				// Maybe fall back to a discovery session?
-				return err
-			}
-			offer, err := tx.QueryOffer(*info, sl)
-			if err != nil {
-				// We shouldn't fail here, the transfer could still work with other peers
-				log.Error().Err(err).Str("id", info.ID.String()).Msg("querying from peer")
-			} else {
-				tx.ApplyOffer(offer)
-			}
-		}
-
-		log.Info().Msg("waiting for triage")
-
-		// Triage waits until we select the first offer it might not mean the first
-		// offer that we receive depending on the strategy used
-		selection, err := tx.Triage()
-		if err != nil {
-			return err
-		}
-		resp := selection.Offer
-
-		log.Info().Msg("selected an offer")
-
-		results <- GetResult{
-			Size:         int64(resp.Size),
-			Status:       "DealStatusSelectedOffer",
-			UnsealPrice:  filecoin.FIL(resp.UnsealPrice).Short(),
-			TotalPrice:   filecoin.FIL(resp.RetrievalPrice()).Short(),
-			PricePerByte: filecoin.FIL(resp.MinPricePerByte).Short(),
-		}
-
-		// TODO: accept all by default but we should be able to pass flag to provide
-		// confirmation before retrieving
-		selection.Exec(exchange.DealSel(sl))
-
-	} else {
-		// No need for triage we already know the offer
-		tx = nd.exch.Tx(ctx, exchange.WithRoot(c), exchange.WithStrategy(strategy))
-		defer tx.Close()
-
-		info, err := offer.AddrInfo()
-		if err != nil {
-			return err
-		}
-
-		// Will be selected automatically in the strategy
-		offer, err := tx.QueryOffer(*info, sl)
-		if err != nil {
-			return err
-		}
-		tx.ApplyOffer(offer)
-	}
-	now := time.Now()
-	discDuration := now.Sub(start)
-
-	var dref exchange.DealRef
-	select {
-	case dref = <-tx.Ongoing():
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	log.Info().Msg("started transfer")
-
-	results <- GetResult{
-		DealID: dref.ID.String(),
-	}
-
-	select {
-	case res := <-tx.Done():
-		log.Info().Msg("finished transfer")
-		if res.Err != nil {
-			return res.Err
-		}
-		end := time.Now()
-		transDuration := end.Sub(start) - discDuration
-		if args.Out != "" {
-			f, err := tx.GetFile(args.Key)
-			if err != nil {
-				return err
-			}
-			err = files.WriteTo(f, args.Out)
-			if err != nil {
-				return err
-			}
-		}
-
-		var keys [][]byte
-		if args.Key != "" {
-			keys = append(keys, []byte(args.Key))
-		} else {
-			mk, err := utils.MapLoadableKeys(ctx, c, tx.Store().Loader)
-			if err != nil {
-				return err
-			}
-			keys = mk.AsBytes()
-		}
-
-		ref := &exchange.DataRef{
-			PayloadCID:  c,
-			PayloadSize: int64(res.Size),
-			Keys:        keys,
-		}
-
-		err = nd.exch.Index().SetRef(ref)
-		if err == exchange.ErrRefAlreadyExists {
-			if err := nd.exch.Index().UpdateRef(ref); err != nil {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
-
-		select {
-		case results <- GetResult{
-			DiscLatSeconds:  discDuration.Seconds(),
-			TransLatSeconds: transDuration.Seconds(),
-		}:
-		default:
-		}
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
 	}
 }
 
@@ -1104,9 +923,7 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 		p := path.FromString(args.Cid)
 		root, segs, err := path.SplitAbsPath(p)
 		if err != nil {
-			results <- GetResult{
-				Err: err.Error(),
-			}
+			sendErr(err)
 			return
 		}
 
@@ -1114,9 +931,20 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 			args.Key = segs[0]
 		}
 
-		//TODO: strategy option
+		// default to SelectFirst
 		strategy := exchange.SelectFirst
-
+		if args.Strategy != "" {
+			switch args.Strategy {
+			case "SelectFirst":
+				strategy = exchange.SelectFirst
+			case "SelectCheapest":
+				strategy = exchange.SelectCheapest(5, 4*time.Second)
+			case "SelectFirstLowerThan":
+				strategy = exchange.SelectFirstLowerThan(abi.NewTokenAmount(args.MaxPPB))
+			default:
+				sendErr(errors.New("unknown strategy"))
+			}
+		}
 		if args.Strategy == "" && args.MaxPPB > 0 {
 			strategy = exchange.SelectFirstLowerThan(abi.NewTokenAmount(args.MaxPPB))
 		}
@@ -1124,10 +952,14 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 		unsub := nd.exch.Retrieval().Client().SubscribeToEvents(
 			func(event client.Event, state deal.ClientState) {
 				if state.PayloadCID == root {
-					results <- GetResult{
-						TotalPrice:    filecoin.FIL(state.TotalFunds).Short(),
+					select {
+					case results <- GetResult{
+						TotalFunds:    filecoin.FIL(state.TotalFunds).Short(),
+						TotalSpent:    filecoin.FIL(state.FundsSpent).Short(),
 						Status:        deal.Statuses[state.Status],
 						TotalReceived: int64(state.TotalReceived),
+					}:
+					default:
 					}
 				}
 			},
@@ -1135,6 +967,8 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 		defer unsub()
 
 		log.Info().Msg("starting query")
+
+		start := time.Now()
 
 		tx := nd.exch.Tx(ctx, exchange.WithRoot(root), exchange.WithStrategy(strategy), exchange.WithTriage())
 		defer tx.Close()
@@ -1148,47 +982,105 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 			s = sel.Key(args.Key)
 		}
 
-		err = tx.Query(s)
+		// If we already have an offer we can skip routing queries
+		offer, err := nd.omg.GetOffer(root)
 		if err != nil {
-			sendErr(err)
-			return
+
+			err = tx.Query(s)
+			if err != nil {
+				sendErr(err)
+				return
+			}
+			// We can query a specific miner on top of gossip
+			// that offer will be at the top of the list if we receive it
+			if args.Miner != "" {
+				miner, err := address.NewFromString(args.Miner)
+				if err != nil {
+					sendErr(err)
+				}
+				info, err := nd.rs.PeerInfo(ctx, miner)
+				if err != nil {
+					sendErr(err)
+				}
+				offer, err := tx.QueryOffer(*info, s)
+				if err != nil {
+					// We shouldn't fail here, the transfer could still work with other peers
+					log.Error().Err(err).Str("id", info.ID.String()).Msg("querying from peer")
+				} else {
+					tx.ApplyOffer(offer)
+				}
+			}
+
+			log.Info().Msg("waiting for triage")
+
+			// The selection comes back for ALL the content
+			selection, err := tx.Triage()
+			if err != nil {
+				sendErr(err)
+				return
+			}
+			offer = selection.Offer
+
+			log.Info().Msg("selected an offer")
+
+			funds := offer.RetrievalPrice()
+			// If we're fetching entries, the selector and funds need to be updated
+			if args.Key == "" {
+				// for now we must pad the funds quite a bit to account for overlapping blocks
+				// because data-transfer doesn't dedup them yet
+				// added funds are based on an average of 100bytes per key and 10 keys per tx so:
+				// (indexSize = 100 * 10) * (numTransfers = 10) * ppb
+				funds = big.Add(offer.RetrievalPrice(), big.Mul(abi.NewTokenAmount(10000), offer.MinPricePerByte))
+				// Select blocks for the index only
+				s = sel.Entries()
+			}
+
+			results <- GetResult{
+				Size:         int64(offer.Size),
+				Status:       "DealStatusSelectedOffer",
+				UnsealPrice:  filecoin.FIL(offer.UnsealPrice).Short(),
+				TotalFunds:   filecoin.FIL(funds).String(),
+				PricePerByte: filecoin.FIL(offer.MinPricePerByte).Short(),
+			}
+
+			// The offer will execute retrieval of the index only but load the payment channel for
+			// retrieving everything
+			selection.Exec(exchange.DealSel(s), exchange.DealFunds(funds))
+		} else {
+			info, err := offer.AddrInfo()
+			if err != nil {
+				sendErr(err)
+				// TODO: fallback to regular query?
+				return
+			}
+
+			// Will be selected automatically in the strategy
+			offer, err := tx.QueryOffer(*info, s)
+			if err != nil {
+				// TODO: fallback to regular query?
+				sendErr(err)
+				return
+			}
+			tx.ApplyOffer(offer)
+
+			results <- GetResult{
+				Size:         int64(offer.Size),
+				Status:       "DealStatusSelectedOffer",
+				UnsealPrice:  filecoin.FIL(offer.UnsealPrice).Short(),
+				TotalFunds:   filecoin.FIL(offer.RetrievalPrice()).String(),
+				PricePerByte: filecoin.FIL(offer.MinPricePerByte).Short(),
+			}
+
+			selection, err := tx.Triage()
+			if err != nil {
+				sendErr(err)
+				return
+			}
+			selection.Exec()
 		}
 
-		log.Info().Msg("waiting for triage")
-
-		// The selection comes back for ALL the content
-		selection, err := tx.Triage()
-		if err != nil {
-			sendErr(err)
-			return
-		}
-		resp := selection.Offer
-
-		log.Info().Msg("selected an offer")
-
-		funds := resp.RetrievalPrice()
-		// If we're fetching entries, the selector and funds need to be updated
-		if args.Key == "" {
-			// for now we must pad the funds quite a bit to account for overlapping blocks
-			// because data-transfer doesn't dedup them yet
-			// added funds are based on an average of 100bytes per key and 10 keys per tx so:
-			// (indexSize = 100 * 10) * (numTransfers = 10) * ppb
-			funds = big.Add(resp.RetrievalPrice(), big.Mul(abi.NewTokenAmount(10000), resp.MinPricePerByte))
-			// Select blocks for the index only
-			s = sel.Entries()
-		}
-
-		results <- GetResult{
-			Size:         int64(resp.Size),
-			Status:       "DealStatusSelectedOffer",
-			UnsealPrice:  filecoin.FIL(resp.UnsealPrice).Short(),
-			TotalPrice:   filecoin.FIL(funds).String(),
-			PricePerByte: filecoin.FIL(resp.MinPricePerByte).Short(),
-		}
-
-		// The offer will execute retrieval of the index only but load the payment channel for
-		// retrieving everything
-		selection.Exec(exchange.DealSel(s), exchange.DealFunds(funds))
+		now := time.Now()
+		discDuration := now.Sub(start)
 
 		var dref exchange.DealRef
 		select {
@@ -1211,14 +1103,37 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 				sendErr(res.Err)
 				return
 			}
-			// transfer was successful so we keep the offer around
-			err := nd.omg.SetOffer(root, resp)
-			if err != nil {
-				log.Error().Err(err).Msg("setting offer")
+
+			if args.Key == "" {
+				// transfer was successful so we keep the offer around
+				// we were just retrieving the index
+				err := nd.omg.SetOffer(root, offer)
+				if err != nil {
+					log.Error().Err(err).Msg("setting offer")
+				}
 			}
-			nd.exch.Index().SetRef(tx.Ref())
-			results <- GetResult{
-				Status: "Completed",
+
+			ref := tx.Ref()
+			err = nd.exch.Index().SetRef(tx.Ref())
+			if err == exchange.ErrRefAlreadyExists {
+				if err := nd.exch.Index().UpdateRef(ref); err != nil {
+					log.Error().Err(err).Msg("updating ref")
+				}
+			} else if err != nil {
+				sendErr(err)
+				return
+			}
+
+			end := time.Now()
+			transDuration := end.Sub(start) - discDuration
+
+			select {
+			case results <- GetResult{
+				Status:          "Completed",
+				DiscLatSeconds:  discDuration.Seconds(),
+				TransLatSeconds: transDuration.Seconds(),
+			}:
+			default:
 			}
 			return
 		case <-ctx.Done():

--- a/node/popn.go
+++ b/node/popn.go
@@ -1107,6 +1107,7 @@ func (nd *node) Load(ctx context.Context, args *GetArgs) (chan GetResult, error)
 		unsub := nd.exch.Retrieval().Client().SubscribeToEvents(
 			func(event client.Event, state deal.ClientState) {
 				if state.PayloadCID == root {
+					fmt.Println("status", deal.Statuses[state.Status], state.Message)
 					results <- GetResult{
 						TotalPrice:    filecoin.FIL(state.TotalFunds).Short(),
 						Status:        deal.Statuses[state.Status],
@@ -1152,8 +1153,8 @@ func (nd *node) PreloadEntries(ctx context.Context, args *GetArgs) (chan GetResu
 
 		unsub := nd.exch.Retrieval().Client().SubscribeToEvents(
 			func(event client.Event, state deal.ClientState) {
-				fmt.Println("status", deal.Statuses[state.Status], state.Message)
 				if state.PayloadCID == root {
+					fmt.Println("status", deal.Statuses[state.Status], state.Message)
 					results <- GetResult{
 						TotalPrice:    filecoin.FIL(state.TotalFunds).Short(),
 						Status:        deal.Statuses[state.Status],

--- a/node/server.go
+++ b/node/server.go
@@ -175,8 +175,20 @@ func (s *server) getHandler(w http.ResponseWriter, r *http.Request) {
 
 	has := tx.IsLocal(key)
 	if !has {
-		http.Error(w, "content not cached on this node", http.StatusNotFound)
-		return
+		// If there is already a payment channel open we can handle it
+		// else the delay for loading a payment channel is not reasonnable for an HTTP request
+		_, err = s.node.omg.GetOffer(root)
+		if err != nil {
+			http.Error(w, "content not cached on this node", http.StatusNotFound)
+			return
+		}
+		results, err := s.node.Load(r.Context(), &GetArgs{Cid: urlPath})
+		if err != nil {
+			http.Error(w, "failed to load", http.StatusInternalServerError)
+			return
+		}
+		for range results {
+		}
 	}
 
 	if key == "" {

--- a/node/server.go
+++ b/node/server.go
@@ -151,8 +151,8 @@ func (s *server) addUserHeaders(w http.ResponseWriter) {
 	w.Header()["Access-Control-Expose-Headers"] = []string{"IPFS-Hash"}
 }
 
-// HTTP get does not retrieve content but only serves content already cached locally
-// to make sure content is loaded use JSON RPC method Load available via websocket
+// HTTP get does not retrieve content but only serves content already cached locally or for which a loaded
+// paychannel already exists to make sure content is loaded use JSON RPC method Load available via websocket
 func (s *server) getHandler(w http.ResponseWriter, r *http.Request) {
 	urlPath := r.URL.Path
 

--- a/payments/channel.go
+++ b/payments/channel.go
@@ -818,8 +818,6 @@ func (ch *channel) checkVoucherValidUnlocked(ctx context.Context, chAddr address
 		return nil, fmt.Errorf("totalRedeemedWithVoucher: %w", err)
 	}
 
-	fmt.Println("availableFunds", totalRedeemed, act.Balance)
-
 	// Total required balance must not exceed actor balance
 	if act.Balance.LessThan(totalRedeemed) {
 		return nil, newErrInsufficientFunds(filecoin.BigSub(totalRedeemed, act.Balance))

--- a/payments/channel.go
+++ b/payments/channel.go
@@ -818,6 +818,8 @@ func (ch *channel) checkVoucherValidUnlocked(ctx context.Context, chAddr address
 		return nil, fmt.Errorf("totalRedeemedWithVoucher: %w", err)
 	}
 
+	fmt.Println("availableFunds", totalRedeemed, act.Balance)
+
 	// Total required balance must not exceed actor balance
 	if act.Balance.LessThan(totalRedeemed) {
 		return nil, newErrInsufficientFunds(filecoin.BigSub(totalRedeemed, act.Balance))
@@ -997,7 +999,7 @@ func (ch *channel) currentAvailableFunds(channelID string, queuedAmt filecoin.Bi
 		PendingAmt:          channelInfo.PendingAmount,
 		PendingWaitSentinel: waitSentinel,
 		QueuedAmt:           queuedAmt,
-		VoucherReedeemedAmt: totalRedeemed,
+		VoucherRedeemedAmt:  totalRedeemed,
 	}, nil
 }
 
@@ -1197,7 +1199,7 @@ type AvailableFunds struct {
 	QueuedAmt filecoin.BigInt
 	// VoucherRedeemedAmt is the amount that is redeemed by vouchers on-chain
 	// and in the local datastore
-	VoucherReedeemedAmt filecoin.BigInt
+	VoucherRedeemedAmt filecoin.BigInt
 }
 
 // VoucherCreateResult is the response to createVoucher method

--- a/payments/channel.go
+++ b/payments/channel.go
@@ -692,7 +692,7 @@ func (ch *channel) addVoucherUnlocked(ctx context.Context, chAddr address.Addres
 	}
 
 	// Check voucher validity
-	laneStates, err := ch.checkVoucherValidUnlocked(ctx, chAddr, sv)
+	laneStates, balance, err := ch.checkVoucherValidUnlocked(ctx, chAddr, sv)
 	if err != nil {
 		return filecoin.NewInt(0), err
 	}
@@ -721,58 +721,66 @@ func (ch *channel) addVoucherUnlocked(ctx context.Context, chAddr address.Addres
 		ci.NextLane = sv.Lane + 1
 	}
 
+	// This is used in the case of a provider adding vouchers. The Amount should be 0 since we didn't
+	// create the channel. As a result we can avoid an extra call to the actor state when needing to
+	// check available funds.
+	if ci.Amount.LessThan(balance) {
+		ci.Amount = balance
+	}
+
 	return delta, ch.store.putChannelInfo(ci)
 }
 
-func (ch *channel) checkVoucherValidUnlocked(ctx context.Context, chAddr address.Address, sv *paych.SignedVoucher) (map[uint64]LaneState, error) {
+func (ch *channel) checkVoucherValidUnlocked(ctx context.Context, chAddr address.Address, sv *paych.SignedVoucher) (map[uint64]LaneState, filecoin.BigInt, error) {
+	ei := filecoin.EmptyInt
 	if sv.ChannelAddr != chAddr {
-		return nil, fmt.Errorf("voucher ChannelAddr doesn't match channel address, got %s, expected %s", sv.ChannelAddr, chAddr)
+		return nil, ei, fmt.Errorf("voucher ChannelAddr doesn't match channel address, got %s, expected %s", sv.ChannelAddr, chAddr)
 	}
 
 	act, err := ch.api.StateGetActor(ctx, chAddr, filecoin.EmptyTSK)
 	if err != nil {
-		return nil, err
+		return nil, ei, err
 	}
 
 	// Load payment channel actor state
 	pchState, err := ch.loadActorState(chAddr)
 	if err != nil {
-		return nil, fmt.Errorf("loadActorState: %w", err)
+		return nil, ei, fmt.Errorf("loadActorState: %w", err)
 	}
 
 	// Load channel "From" account actor state
 	f, err := pchState.From()
 	if err != nil {
-		return nil, err
+		return nil, ei, err
 	}
 
 	from, err := ch.api.StateAccountKey(ctx, f, filecoin.EmptyTSK)
 	if err != nil {
-		return nil, err
+		return nil, ei, err
 	}
 
 	// verify voucher signature
 	vb, err := sv.SigningBytes()
 	if err != nil {
-		return nil, err
+		return nil, ei, err
 	}
 
 	sig, err := wallet.SigTypeSig(sv.Signature.Type, ch.wal.Signers())
 	if err != nil {
-		return nil, err
+		return nil, ei, err
 	}
 
 	// TODO: technically, either party may create and sign a voucher.
 	// However, for now, we only accept them from the channel creator.
 	// More complex handling logic can be added later
 	if err := sig.Verify(sv.Signature.Data, from, vb); err != nil {
-		return nil, err
+		return nil, ei, err
 	}
 
 	// Check the voucher against the highest known voucher nonce / value
 	laneStates, err := ch.laneState(pchState, chAddr)
 	if err != nil {
-		return nil, fmt.Errorf("laneState: %v", err)
+		return nil, ei, fmt.Errorf("laneState: %v", err)
 	}
 
 	// If the new voucher nonce value is less than the highest known
@@ -781,20 +789,20 @@ func (ch *channel) checkVoucherValidUnlocked(ctx context.Context, chAddr address
 	if lsExists {
 		n, err := ls.Nonce()
 		if err != nil {
-			return nil, err
+			return nil, ei, err
 		}
 
 		if sv.Nonce <= n {
-			return nil, fmt.Errorf("nonce too low")
+			return nil, ei, fmt.Errorf("nonce too low")
 		}
 
 		// If the voucher amount is less than the highest known voucher amount
 		r, err := ls.Redeemed()
 		if err != nil {
-			return nil, err
+			return nil, ei, err
 		}
 		if sv.Amount.LessThanEqual(r) {
-			return nil, fmt.Errorf("voucher amount is lower than amount for voucher with lower nonce")
+			return nil, ei, fmt.Errorf("voucher amount is lower than amount for voucher with lower nonce")
 		}
 	}
 
@@ -815,19 +823,19 @@ func (ch *channel) checkVoucherValidUnlocked(ctx context.Context, chAddr address
 	// total:   7
 	totalRedeemed, err := ch.totalRedeemedWithVoucher(laneStates, sv)
 	if err != nil {
-		return nil, fmt.Errorf("totalRedeemedWithVoucher: %w", err)
+		return nil, ei, fmt.Errorf("totalRedeemedWithVoucher: %w", err)
 	}
 
 	// Total required balance must not exceed actor balance
 	if act.Balance.LessThan(totalRedeemed) {
-		return nil, newErrInsufficientFunds(filecoin.BigSub(totalRedeemed, act.Balance))
+		return nil, ei, newErrInsufficientFunds(filecoin.BigSub(totalRedeemed, act.Balance))
 	}
 
 	if len(sv.Merges) != 0 {
-		return nil, fmt.Errorf("dont currently support paych lane merges")
+		return nil, ei, fmt.Errorf("dont currently support paych lane merges")
 	}
 
-	return laneStates, nil
+	return laneStates, act.Balance, nil
 }
 
 // Get the total redeemed amount across all lanes, after applying the voucher

--- a/payments/channel_test.go
+++ b/payments/channel_test.go
@@ -199,7 +199,7 @@ func TestChannel(t *testing.T) {
 	}
 	api.SetObjectReader(objReader)
 
-	api.SetAccountKey(ch.from)
+	api.SetAccountKey(payerAddr, ch.from)
 
 	voucher := paych.SignedVoucher{Amount: fil.NewInt(123), Lane: 1}
 	res, err := ch.createVoucher(ctx, chAddr, voucher)

--- a/payments/manager.go
+++ b/payments/manager.go
@@ -30,7 +30,6 @@ type Manager interface {
 	AllocateLane(context.Context, address.Address) (uint64, error)
 	AddVoucherInbound(context.Context, address.Address, *paych.SignedVoucher, []byte, filecoin.BigInt) (filecoin.BigInt, error)
 	ChannelAvailableFunds(address.Address) (*AvailableFunds, error)
-	ChannelBalance(context.Context, address.Address) (big.Int, error)
 	SubmitAllVouchers(context.Context, address.Address) error
 	Settle(context.Context, address.Address) error
 	StartAutoCollect(context.Context) error
@@ -153,16 +152,6 @@ func (p *Payments) ChannelAvailableFunds(chAddr address.Address) (*AvailableFund
 	}
 
 	return ch.availableFunds(ci.ChannelID)
-}
-
-// ChannelBalance returns the total balance of the paych actor
-// This is useful in the case we are not tracking this channel.
-func (p *Payments) ChannelBalance(ctx context.Context, chAddr address.Address) (big.Int, error) {
-	actState, err := p.api.StateReadState(ctx, chAddr, filecoin.EmptyTSK)
-	if err != nil {
-		return big.Zero(), err
-	}
-	return actState.Balance, nil
 }
 
 // ListChannels we have in the store

--- a/payments/manager_test.go
+++ b/payments/manager_test.go
@@ -18,6 +18,7 @@ import (
 	dssync "github.com/ipfs/go-datastore/sync"
 	keystore "github.com/ipfs/go-ipfs-keystore"
 	fil "github.com/myelnet/pop/filecoin"
+	"github.com/myelnet/pop/internal/testutil"
 	"github.com/myelnet/pop/wallet"
 	"github.com/stretchr/testify/require"
 )
@@ -63,7 +64,7 @@ func TestAddFunds(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, cis, 0)
 
-	lookup := formatMsgLookup(t, chAddr)
+	lookup := testutil.FormatMsgLookup(t, chAddr)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -162,7 +163,7 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 	createRes, err := mgr.GetChannel(ctx, from, to, createAmt)
 	require.NoError(t, err)
 
-	lookup := formatMsgLookup(t, chAddr)
+	lookup := testutil.FormatMsgLookup(t, chAddr)
 	// Send message confirmation to create channel
 	api.SetMsgLookup(lookup)
 
@@ -199,7 +200,7 @@ func TestPaychAddVoucherAfterAddFunds(t *testing.T) {
 	api.SetActorState(&actState)
 	// See channel tests for note about this
 	objReader := func(c cid.Cid) []byte {
-		var bg bytesGetter
+		var bg testutil.BytesGetter
 		rt.StoreGet(c, &bg)
 		return bg.Bytes()
 	}
@@ -312,7 +313,7 @@ func TestBestSpendable(t *testing.T) {
 	api.SetActorState(&actState)
 	// object reader to send a serialized object
 	objReader := func(c cid.Cid) []byte {
-		var bg bytesGetter
+		var bg testutil.BytesGetter
 		rt.StoreGet(c, &bg)
 		return bg.Bytes()
 	}
@@ -456,7 +457,7 @@ func TestCollectChannel(t *testing.T) {
 	api.SetActorState(&actState)
 	// object reader to send a serialized object
 	objReader := func(c cid.Cid) []byte {
-		var bg bytesGetter
+		var bg testutil.BytesGetter
 		rt.StoreGet(c, &bg)
 		return bg.Bytes()
 	}
@@ -519,7 +520,7 @@ func TestCollectChannel(t *testing.T) {
 	// update our actor state to the api so it's queryable
 	api.SetActorState(&actState)
 
-	lookup := formatMsgLookup(t, chAddr)
+	lookup := testutil.FormatMsgLookup(t, chAddr)
 	// We should have 3 chain txs we're waiting for
 	for i := 0; i < 3; i++ {
 		api.SetMsgLookup(lookup)

--- a/retrieval/askstore.go
+++ b/retrieval/askstore.go
@@ -8,15 +8,15 @@ import (
 	"github.com/myelnet/pop/retrieval/deal"
 )
 
-// AskStore is actually for storing QueryResponse objects
+// AskStore is actually for storing Offers we made so we can validate requests against them
 // we don't currently need to persist this beyond node restart
 type AskStore struct {
 	lk   sync.RWMutex
-	asks map[cid.Cid]deal.QueryResponse
+	asks map[cid.Cid]deal.Offer
 }
 
 // SetAsk stores retrieval provider's ask for a given content root
-func (s *AskStore) SetAsk(k cid.Cid, ask deal.QueryResponse) error {
+func (s *AskStore) SetAsk(k cid.Cid, ask deal.Offer) error {
 	s.lk.Lock()
 	defer s.lk.Unlock()
 
@@ -25,7 +25,7 @@ func (s *AskStore) SetAsk(k cid.Cid, ask deal.QueryResponse) error {
 }
 
 // GetAsk returns the current retrieval ask for a given content root, or nil if one does not exist.
-func (s *AskStore) GetAsk(k cid.Cid) deal.QueryResponse {
+func (s *AskStore) GetAsk(k cid.Cid) deal.Offer {
 	s.lk.RLock()
 	defer s.lk.RUnlock()
 
@@ -34,7 +34,7 @@ func (s *AskStore) GetAsk(k cid.Cid) deal.QueryResponse {
 		// we don't have a specific ask for this CID so let's returns a default
 		// response. TODO: need more context as to why this content is being retrieved,
 		// which region, peer etc.
-		return deal.QueryResponse{
+		return deal.Offer{
 			MinPricePerByte:            big.Zero(),
 			MaxPaymentInterval:         deal.DefaultPaymentInterval,
 			MaxPaymentIntervalIncrease: deal.DefaultPaymentIntervalIncrease,

--- a/retrieval/client/fsm.go
+++ b/retrieval/client/fsm.go
@@ -588,7 +588,7 @@ func CheckFunds(ctx fsm.Context, env DealEnvironment, ds deal.ClientState) error
 	}
 
 	total := calcAmountToSend(ds)
-	unredeemedFunds := big.Sub(availableFunds.ConfirmedAmt, availableFunds.VoucherReedeemedAmt)
+	unredeemedFunds := big.Sub(availableFunds.ConfirmedAmt, availableFunds.VoucherRedeemedAmt)
 	shortfall := big.Sub(total, unredeemedFunds)
 
 	// The shortfall is negative when there is more funds in the channel than the requested payment amount

--- a/retrieval/client/fsm.go
+++ b/retrieval/client/fsm.go
@@ -134,7 +134,7 @@ var FSMEvents = fsm.Events{
 		// created for an earlier deal but the initial funding for this deal
 		// was being added, then we still need to allocate a payment channel
 		// lane
-		FromMany(deal.StatusPaymentChannelCreating, deal.StatusPaymentChannelAddingInitialFunds).
+		FromMany(deal.StatusPaymentChannelCreating, deal.StatusPaymentChannelAddingInitialFunds, deal.StatusAccepted).
 		To(deal.StatusPaymentChannelAllocatingLane).
 		// If the payment channel ran out of funds and needed to be topped up,
 		// then the payment channel lane already exists so just move straight
@@ -455,6 +455,10 @@ func SetupPaymentChannelStart(ctx fsm.Context, environment DealEnvironment, ds d
 
 	if res.Channel == address.Undef {
 		return ctx.Trigger(EventPaymentChannelCreateInitiated, res.WaitSentinel)
+	}
+
+	if res.WaitSentinel == cid.Undef {
+		return ctx.Trigger(EventPaymentChannelReady, res.Channel)
 	}
 
 	return ctx.Trigger(EventPaymentChannelAddingFunds, res.WaitSentinel, res.Channel)

--- a/retrieval/deal/types_cbor_gen.go
+++ b/retrieval/deal/types_cbor_gen.go
@@ -69,7 +69,6 @@ func (t *QueryParams) MarshalCBOR(w io.Writer) error {
 	if err := t.Selector.MarshalCBOR(w); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -106,17 +105,6 @@ func (t *QueryParams) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		switch name {
-		// t.Selector (typegen.Deferred) (struct)
-		case "Selector":
-
-			{
-
-				t.Selector = new(cbg.Deferred)
-
-				if err := t.Selector.UnmarshalCBOR(br); err != nil {
-					return xerrors.Errorf("failed to read deferred field: %w", err)
-				}
-			}
 		// t.PieceCID (cid.Cid) (struct)
 		case "PieceCID":
 
@@ -139,6 +127,17 @@ func (t *QueryParams) UnmarshalCBOR(r io.Reader) error {
 					t.PieceCID = &c
 				}
 
+			}
+			// t.Selector (typegen.Deferred) (struct)
+		case "Selector":
+
+			{
+
+				t.Selector = new(cbg.Deferred)
+
+				if err := t.Selector.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("failed to read deferred field: %w", err)
+				}
 			}
 
 		default:
@@ -2464,6 +2463,341 @@ func (t *PaymentInfo) UnmarshalCBOR(r io.Reader) error {
 					return fmt.Errorf("wrong type for uint64 field")
 				}
 				t.Lane = uint64(extra)
+
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}
+func (t *Offer) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write([]byte{169}); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.ID (string) (string)
+	if len("ID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ID")); err != nil {
+		return err
+	}
+
+	if len(t.ID) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.ID was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.ID))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.ID)); err != nil {
+		return err
+	}
+
+	// t.PeerAddr ([]uint8) (slice)
+	if len("PeerAddr") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PeerAddr\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PeerAddr"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PeerAddr")); err != nil {
+		return err
+	}
+
+	if len(t.PeerAddr) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.PeerAddr was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajByteString, uint64(len(t.PeerAddr))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(t.PeerAddr[:]); err != nil {
+		return err
+	}
+
+	// t.PayloadCID (cid.Cid) (struct)
+	if len("PayloadCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PayloadCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PayloadCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PayloadCID")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteCidBuf(scratch, w, t.PayloadCID); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PayloadCID: %w", err)
+	}
+
+	// t.Size (uint64) (uint64)
+	if len("Size") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Size\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Size"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Size")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Size)); err != nil {
+		return err
+	}
+
+	// t.PaymentAddress (address.Address) (struct)
+	if len("PaymentAddress") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentAddress\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentAddress"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentAddress")); err != nil {
+		return err
+	}
+
+	if err := t.PaymentAddress.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.MinPricePerByte (big.Int) (struct)
+	if len("MinPricePerByte") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MinPricePerByte\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MinPricePerByte"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MinPricePerByte")); err != nil {
+		return err
+	}
+
+	if err := t.MinPricePerByte.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.MaxPaymentInterval (uint64) (uint64)
+	if len("MaxPaymentInterval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MaxPaymentInterval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MaxPaymentInterval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MaxPaymentInterval")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.MaxPaymentInterval)); err != nil {
+		return err
+	}
+
+	// t.MaxPaymentIntervalIncrease (uint64) (uint64)
+	if len("MaxPaymentIntervalIncrease") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MaxPaymentIntervalIncrease\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MaxPaymentIntervalIncrease"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MaxPaymentIntervalIncrease")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.MaxPaymentIntervalIncrease)); err != nil {
+		return err
+	}
+
+	// t.UnsealPrice (big.Int) (struct)
+	if len("UnsealPrice") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"UnsealPrice\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("UnsealPrice"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("UnsealPrice")); err != nil {
+		return err
+	}
+
+	if err := t.UnsealPrice.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *Offer) UnmarshalCBOR(r io.Reader) error {
+	*t = Offer{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Offer: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.ID (string) (string)
+		case "ID":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.ID = string(sval)
+			}
+			// t.PeerAddr ([]uint8) (slice)
+		case "PeerAddr":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.ByteArrayMaxLen {
+				return fmt.Errorf("t.PeerAddr: byte array too large (%d)", extra)
+			}
+			if maj != cbg.MajByteString {
+				return fmt.Errorf("expected byte array")
+			}
+
+			if extra > 0 {
+				t.PeerAddr = make([]uint8, extra)
+			}
+
+			if _, err := io.ReadFull(br, t.PeerAddr[:]); err != nil {
+				return err
+			}
+			// t.PayloadCID (cid.Cid) (struct)
+		case "PayloadCID":
+
+			{
+
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
+				}
+
+				t.PayloadCID = c
+
+			}
+			// t.Size (uint64) (uint64)
+		case "Size":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Size = uint64(extra)
+
+			}
+			// t.PaymentAddress (address.Address) (struct)
+		case "PaymentAddress":
+
+			{
+
+				if err := t.PaymentAddress.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PaymentAddress: %w", err)
+				}
+
+			}
+			// t.MinPricePerByte (big.Int) (struct)
+		case "MinPricePerByte":
+
+			{
+
+				if err := t.MinPricePerByte.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.MinPricePerByte: %w", err)
+				}
+
+			}
+			// t.MaxPaymentInterval (uint64) (uint64)
+		case "MaxPaymentInterval":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.MaxPaymentInterval = uint64(extra)
+
+			}
+			// t.MaxPaymentIntervalIncrease (uint64) (uint64)
+		case "MaxPaymentIntervalIncrease":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.MaxPaymentIntervalIncrease = uint64(extra)
+
+			}
+			// t.UnsealPrice (big.Int) (struct)
+		case "UnsealPrice":
+
+			{
+
+				if err := t.UnsealPrice.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.UnsealPrice: %w", err)
+				}
 
 			}
 

--- a/retrieval/environments.go
+++ b/retrieval/environments.go
@@ -114,11 +114,6 @@ func (pve *providerValidationEnvironment) CheckDealParams(ds deal.ProviderState)
 	return nil
 }
 
-// RunDealDecisioningLogic runs custom deal decision logic to decide if a deal is accepted, if present
-func (pve *providerValidationEnvironment) RunDealDecisioningLogic(ctx context.Context, state deal.ProviderState) (bool, string, error) {
-	return true, "", nil
-}
-
 // StateMachines returns the FSM Group to begin tracking with
 func (pve *providerValidationEnvironment) BeginTracking(pds deal.ProviderState) error {
 	err := pve.p.stateMachines.Begin(pds.Identifier(), &pds)

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -85,12 +85,12 @@ type Provider struct {
 }
 
 // GetAsk returns the current deal parameters this provider accepts for a given content ID
-func (p *Provider) GetAsk(k cid.Cid) deal.QueryResponse {
+func (p *Provider) GetAsk(k cid.Cid) deal.Offer {
 	return p.askStore.GetAsk(k)
 }
 
 // SetAsk sets the deal parameters this provider accepts
-func (p *Provider) SetAsk(k cid.Cid, ask deal.QueryResponse) {
+func (p *Provider) SetAsk(k cid.Cid, ask deal.Offer) {
 	err := p.askStore.SetAsk(k, ask)
 	if err != nil {
 		log.Error().Err(err).Msg("error setting retrieval ask")
@@ -147,7 +147,7 @@ func New(
 		dataTransfer: dt,
 		pay:          pay,
 		askStore: &AskStore{
-			asks: make(map[cid.Cid]deal.QueryResponse),
+			asks: make(map[cid.Cid]deal.Offer),
 		},
 	}
 	p.stateMachines, err = fsm.New(namespace.Wrap(ds, datastore.NewKey("provider-v0")), fsm.Parameters{

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -293,7 +293,7 @@ totalFunds: %s
 			unsealPrice := big.Zero()
 			params, err := deal.NewParams(pricePerByte, testCase.paymentInterval, paymentIntervalIncrease, selectors.All(), nil, unsealPrice)
 			require.NoError(t, err)
-			ask := deal.QueryResponse{
+			ask := deal.Offer{
 				MinPricePerByte:            pricePerByte,
 				MaxPaymentInterval:         testCase.paymentInterval,
 				MaxPaymentIntervalIncrease: paymentIntervalIncrease,

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -70,10 +70,10 @@ func (p *mockPayments) CreateVoucher(ctx context.Context, addr address.Address, 
 		TimeLockMax: abi.ChainEpoch(0),
 		Lane:        lane,
 		Nonce:       0,
-		Amount:      big.Sub(amt, p.chFunds.VoucherReedeemedAmt),
+		Amount:      big.Sub(amt, p.chFunds.VoucherRedeemedAmt),
 		// Signature:      sig,
 	}
-	p.chFunds.VoucherReedeemedAmt = big.Add(p.chFunds.VoucherReedeemedAmt, vouch.Amount)
+	p.chFunds.VoucherRedeemedAmt = big.Add(p.chFunds.VoucherRedeemedAmt, vouch.Amount)
 	vouchRes := &payments.VoucherCreateResult{
 		Voucher:   vouch,
 		Shortfall: filecoin.NewInt(0),

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -271,8 +271,8 @@ totalFunds: %s
 				case deal.StatusInsufficientFunds:
 					// Simulate reaprovisioning the payment channel
 					pay1.SetChannelAvailableFunds(payments.AvailableFunds{
-						ConfirmedAmt:        big.Add(pay1.chFunds.ConfirmedAmt, state.VoucherShortfall),
-						VoucherReedeemedAmt: pay1.chFunds.VoucherReedeemedAmt,
+						ConfirmedAmt:       big.Add(pay1.chFunds.ConfirmedAmt, state.VoucherShortfall),
+						VoucherRedeemedAmt: pay1.chFunds.VoucherRedeemedAmt,
 					})
 					// Need to wait a bit for status to update in state machine
 					time.Sleep(10 * time.Millisecond)
@@ -348,8 +348,8 @@ func addZeroesToAvailableFunds(channelAvailableFunds payments.AvailableFunds) pa
 	if channelAvailableFunds.QueuedAmt.Nil() {
 		channelAvailableFunds.QueuedAmt = big.Zero()
 	}
-	if channelAvailableFunds.VoucherReedeemedAmt.Nil() {
-		channelAvailableFunds.VoucherReedeemedAmt = big.Zero()
+	if channelAvailableFunds.VoucherRedeemedAmt.Nil() {
+		channelAvailableFunds.VoucherRedeemedAmt = big.Zero()
 	}
 	return channelAvailableFunds
 }

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -108,6 +108,10 @@ func (p *mockPayments) StartAutoCollect(ctx context.Context) error {
 	return nil
 }
 
+func (p *mockPayments) SubmitAllVouchers(context.Context, address.Address) error {
+	return nil
+}
+
 type mockStoreIDGetter struct {
 	id  multistore.StoreID
 	err error

--- a/retrieval/validators.go
+++ b/retrieval/validators.go
@@ -20,6 +20,7 @@ import (
 	"github.com/myelnet/pop/selectors"
 )
 
+// TODO: make this nicer
 var allSelectorBytes []byte
 
 func init() {
@@ -32,8 +33,6 @@ func init() {
 type ValidationEnvironment interface {
 	// CheckDealParams verifies the given deal params are acceptable
 	CheckDealParams(deal.ProviderState) error
-	// RunDealDecisioningLogic runs custom deal decision logic to decide if a deal is accepted, if present
-	RunDealDecisioningLogic(ctx context.Context, state deal.ProviderState) (bool, string, error)
 	// StateMachines returns the FSM Group to begin tracking with
 	BeginTracking(pds deal.ProviderState) error
 	// NextStoreID allocates a store for this deal
@@ -122,14 +121,6 @@ func (rv *ProviderRequestValidator) acceptDeal(d *deal.ProviderState) (deal.Stat
 	err := rv.env.CheckDealParams(*d)
 	if err != nil {
 		return deal.StatusRejected, err
-	}
-
-	accepted, reason, err := rv.env.RunDealDecisioningLogic(context.TODO(), *d)
-	if err != nil {
-		return deal.StatusErrored, err
-	}
-	if !accepted {
-		return deal.StatusRejected, fmt.Errorf(reason)
 	}
 
 	// This also verifies we do have the content ready to provide


### PR DESCRIPTION
This is a rather significant amount of changes as progressively retrieving keys required a bit of refactoring.

The aim of this PR is to give the ability to call `Load(<root>)` for retrieving the index of all entries of a given DAG root from a provider and loading the necessary funds to later retrieve parts or all of the DAG. Therefore, the Load RPC allows the following:
- `Load(<root>)` --> Retrieve the index (map with all the keys and entries without resolving the links) and load funds to pay for retrieving all of them with a select provider.
- `Load(<root>/*)` --> Retrieve the index with all linked data
- `Load(<root>/<key>)` --> Retrieve the index and only the linked data for the given key
