### PR TITLE
feat: activate websocket transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,8 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.4.1
 	github.com/libp2p/go-libp2p-swarm v0.4.0
 	github.com/libp2p/go-libp2p-testing v0.4.0
+	github.com/libp2p/go-tcp-transport v0.2.1
+	github.com/libp2p/go-ws-transport v0.4.0
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multibase v0.0.3

--- a/node/popn.go
+++ b/node/popn.go
@@ -43,6 +43,8 @@ import (
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	tcp "github.com/libp2p/go-tcp-transport"
+	websocket "github.com/libp2p/go-ws-transport"
 	"github.com/myelnet/pop/build"
 	"github.com/myelnet/pop/exchange"
 	"github.com/myelnet/pop/filecoin"
@@ -186,9 +188,12 @@ func New(ctx context.Context, opts Options) (*node, error) {
 		ctx,
 		libp2p.Identity(priv),
 		libp2p.ListenAddrStrings(
-			"/ip4/0.0.0.0/tcp/41505",
-			"/ip6/::/tcp/41505",
+			"/ip4/0.0.0.0/tcp/41504",
+			"/ip4/0.0.0.0/tcp/41505/ws",
 		),
+		// Explicitly declare transports
+		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(websocket.New),
 		libp2p.ConnectionManager(connmgr.NewConnManager(
 			20,             // Lowwater
 			60,             // HighWater,


### PR DESCRIPTION
ws and tcp are both default transports but I wanted to explicitly declare them so we don't get confused.