### PR TITLE
fix: return nil when rpc cannot connect

### DIFF
--- a/cmd/pop/cli/cli.go
+++ b/cmd/pop/cli/cli.go
@@ -82,6 +82,13 @@ func Run(args []string) error {
 		log.Logger = log.Output(output)
 	}
 
+	// Uncomment to debug data transfers
+	// ilog.SetLogLevel("dt_graphsync", "debug")
+	// ilog.SetLogLevel("dt-chanmon", "debug")
+	// ilog.SetLogLevel("dt-impl", "debug")
+	// ilog.SetLogLevel("data_transfer", "debug")
+	// ilog.SetLogLevel("data_transfer_network", "debug")
+
 	rootCmd := &ffcli.Command{
 		Name:       "pop",
 		ShortUsage: "pop subcommand [flags]",

--- a/exchange/replication.go
+++ b/exchange/replication.go
@@ -319,7 +319,15 @@ func (r *Replication) AddStore(k cid.Cid, sid multistore.StoreID) error {
 func (r *Replication) GetStore(k cid.Cid) *multistore.Store {
 	r.smu.Lock()
 	defer r.smu.Unlock()
-	return r.stores[k]
+	s, ok := r.stores[k]
+	if !ok {
+		// If no store can be found we return the global store as a last resort
+		return &multistore.Store{
+			Loader: storeutil.LoaderForBlockstore(r.bs),
+			Bstore: r.bs,
+		}
+	}
+	return s
 }
 
 // RmStore cleans up the store when it is not needed anymore

--- a/filecoin/lotus.go
+++ b/filecoin/lotus.go
@@ -44,10 +44,10 @@ func NewLotusRPC(ctx context.Context, addr string, header http.Header) (API, err
 		},
 		header,
 	)
-	res.closer = closer
 	if err != nil {
 		return nil, err
 	}
+	res.closer = closer
 	return &res, nil
 }
 

--- a/filecoin/lotus.go
+++ b/filecoin/lotus.go
@@ -45,7 +45,10 @@ func NewLotusRPC(ctx context.Context, addr string, header http.Header) (API, err
 		header,
 	)
 	res.closer = closer
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 func (a *LotusAPI) Close() {

--- a/internal/utils/repo.go
+++ b/internal/utils/repo.go
@@ -129,7 +129,7 @@ func FormatToken(tok string, tp string) string {
 	} else {
 		token = tok
 	}
-	token = fmt.Sprintf("%s %s", tp, tok)
+	token = fmt.Sprintf("%s %s", tp, token)
 	return token
 }
 

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -192,10 +192,6 @@ func TestRetrieval(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if i != 7 {
-				// Skipping this while we figure out the first block race situation
-				t.Skip()
-			}
 
 			bgCtx := context.Background()
 
@@ -236,7 +232,9 @@ func TestRetrieval(t *testing.T) {
 			rootCid := link.(cidlink.Link).Cid
 
 			n2.SetupDataTransfer(bgCtx, t)
-			pay2 := &mockPayments{}
+			pay2 := &mockPayments{
+				chFunds: &chFunds,
+			}
 			r2, err := New(bgCtx, n2.Ms, n2.Ds, pay2, n2.Dt, n2.Host.ID())
 			require.NoError(t, err)
 


### PR DESCRIPTION
This is a fix without which the node crashes when trying to get the chain head for channel collection when the lotus RPC cannot connect.