### PR TITLE
fix: do not delete index blocks when cleaning blockstore

### DIFF
--- a/exchange/index.go
+++ b/exchange/index.go
@@ -528,17 +528,9 @@ func (idx *Index) CleanBlockStore(ctx context.Context) error {
 
 	cidSet := cid.NewSet()
 
-	err := idx.root.ForEach(ctx, func(k string, val *cbg.Deferred) error {
-		ref := new(DataRef)
-		err := ref.UnmarshalCBOR(bytes.NewReader(val.Raw))
-		if err != nil {
-			return err
-		}
-
-		return utils.WalkDAG(ctx, ref.PayloadCID, idx.bstore, sel.All(), func(blk blocks.Block) error {
-			cidSet.Add(blk.Cid())
-			return nil
-		})
+	err := utils.WalkDAG(ctx, idx.rootCID, idx.bstore, sel.All(), func(blk blocks.Block) error {
+		cidSet.Add(blk.Cid())
+		return nil
 	})
 	if err != nil {
 		return err

--- a/exchange/index.go
+++ b/exchange/index.go
@@ -523,6 +523,11 @@ func (idx *Index) GC() error {
 
 // CleanBlockStore removes blocks from blockstore which CIDs are not in index
 func (idx *Index) CleanBlockStore(ctx context.Context) error {
+	// root may be undefined when we start for the first time
+	if idx.rootCID == cid.Undef {
+		return nil
+	}
+
 	idx.emu.Lock()
 	defer idx.emu.Unlock()
 

--- a/exchange/index_test.go
+++ b/exchange/index_test.go
@@ -713,4 +713,8 @@ func TestCleanBlockStore(t *testing.T) {
 	has, err = idx.Bstore().Has(blk2.Cid())
 	require.NoError(t, err)
 	require.Equal(t, true, has)
+
+	// check we didn't remove index blocks
+	idx, err = NewIndex(ds, bs)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Changed the way we were walking the index to include the index blocks as well