### PR TITLE
feat: migrate influxdb to bcli

### DIFF
--- a/cmd/bcli/main.go
+++ b/cmd/bcli/main.go
@@ -162,6 +162,7 @@ func (c *BrowserClient) Get(ctx context.Context, args *node.GetArgs) {
 	values := make(map[string]interface{})
 	values["content"] = args.Cid
 	values["transfer-duration"] = resp.Timing.WorkerRespondWithSettled
+	values["ppb"] = args.MaxPPB
 
 	c.metrics.Record("retrieval", tags, values)
 	c.send(node.Notify{GetResult: &node.GetResult{}})

--- a/cmd/pop/cli/start.go
+++ b/cmd/pop/cli/start.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/myelnet/pop/internal/utils"
-	"github.com/myelnet/pop/metrics"
 	"github.com/myelnet/pop/node"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/rs/zerolog"
@@ -37,8 +36,8 @@ type PopConfig struct {
 	filTokenType  string
 	domains       string
 	indexEndpoint string
-	logLevel string
-	logDir string
+	logLevel      string
+	logDir        string
 }
 
 var startArgs PopConfig
@@ -179,7 +178,6 @@ Manage your Myel point of presence from the command line.
 
 	opts := node.Options{
 		RepoPath:       path,
-		Metrics:        metrics.GetInfluxParams(),
 		BootstrapPeers: bAddrs,
 		FilEndpoint:    startArgs.filEndpoint,
 		FilToken:       filToken,

--- a/node/popn.go
+++ b/node/popn.go
@@ -51,10 +51,8 @@ import (
 	"github.com/myelnet/pop/filecoin"
 	"github.com/myelnet/pop/infra/build"
 	"github.com/myelnet/pop/internal/utils"
-	"github.com/myelnet/pop/metrics"
 	"github.com/myelnet/pop/retrieval/client"
 	"github.com/myelnet/pop/retrieval/deal"
-	"github.com/myelnet/pop/retrieval/provider"
 	sel "github.com/myelnet/pop/selectors"
 	"github.com/myelnet/pop/wallet"
 	"github.com/rs/zerolog/log"
@@ -107,8 +105,6 @@ var (
 type Options struct {
 	// RepoPath is the file system path to use to persist our datastore
 	RepoPath string
-	// UseInflux is flag determining wether we are pushing pushing statistics to InfluxDB.
-	Metrics *metrics.Config
 	// SocketPath is the unix socket path to listen on
 	SocketPath string
 	// BootstrapPeers is a peer address to connect to for discovering other peers
@@ -142,15 +138,14 @@ type Options struct {
 
 // Pop is the pop node implementation
 type Pop struct {
-	Host    host.Host
-	ds      datastore.Batching
-	bs      blockstore.Blockstore
-	ms      *multistore.MultiStore
-	is      cbor.IpldStore
-	dag     ipldformat.DAGService
-	exch    *exchange.Exchange
-	metrics metrics.MetricsRecorder
-	remind  *RemoteIndex
+	Host   host.Host
+	ds     datastore.Batching
+	bs     blockstore.Blockstore
+	ms     *multistore.MultiStore
+	is     cbor.IpldStore
+	dag    ipldformat.DAGService
+	exch   *exchange.Exchange
+	remind *RemoteIndex
 
 	// opts keeps all the node params set when starting the node
 	opts Options
@@ -286,15 +281,6 @@ func New(ctx context.Context, opts Options) (*Pop, error) {
 		fmt.Printf("==> Generated new FIL address: %s\n", addr)
 	}
 
-	if opts.Metrics != nil {
-		eopts.WatchQueriesFunc = func(q deal.Query) {
-			nd.metrics.Record(
-				"routing-query",
-				map[string]string{},
-				map[string]interface{}{"content": q.PayloadCID.String()})
-		}
-	}
-
 	nd.exch, err = exchange.New(ctx, nd.Host, nd.ds, eopts)
 	if err != nil {
 		return nil, fmt.Errorf("inializing exchange: %w", err)
@@ -340,22 +326,6 @@ func New(ctx context.Context, opts Options) (*Pop, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	nd.metrics = metrics.New(opts.Metrics)
-
-	// subscribe and log provider events
-	nd.exch.Retrieval().Provider().SubscribeToEvents(func(event provider.Event, state deal.ProviderState) {
-		tags := make(map[string]string)
-		tags["requester"] = state.Receiver.String()
-		tags["responder"] = nd.Host.ID().String()
-
-		values := make(map[string]interface{})
-		values["event"] = provider.Events[event]
-		values["status"] = deal.Statuses[state.Status]
-		values["content"] = state.PayloadCID.String()
-
-		nd.metrics.Record("retrieval", tags, values)
-	})
 
 	return nd, nil
 }

--- a/node/server.go
+++ b/node/server.go
@@ -364,14 +364,6 @@ func Run(ctx context.Context, opts Options) error {
 		fmt.Printf("==> Connected to Filecoin RPC at %s\n", opts.FilEndpoint)
 	}
 
-	nd.metrics.Record("check-in",
-		map[string]string{"peer": nd.Host.ID().String()},
-		map[string]interface{}{"msg": "logging-on"})
-
-	if nd.metrics.URL() != "" {
-		fmt.Printf("==> Checked-in with InfluxDB at %s\n", nd.metrics.URL())
-	}
-
 	server := &server{
 		node: nd,
 	}


### PR DESCRIPTION
Removes any influx methods from pop and add a retrieval record call into the Get method of bcli