### PR TITLE
refactor: ppb for content delivery as a flag

### DIFF
--- a/cmd/pop/cli/start.go
+++ b/cmd/pop/cli/start.go
@@ -31,6 +31,7 @@ type PopConfig struct {
 	bootstrap     string
 	capacity      string
 	maxPPB        int
+	ppb           int
 	filEndpoint   string
 	filToken      string
 	filTokenType  string
@@ -64,7 +65,8 @@ The 'pop start' command starts a pop daemon service.
 		fs.StringVar(&startArgs.capacity, "capacity", "100GB", "storage space allocated for the node")
 		fs.DurationVar(&startArgs.replInterval, "replinterval", 0, "at which interval to check for new content from peers. 0 means the feature is deactivated")
 		fs.StringVar(&startArgs.domains, "domains", "", "comma separated list of domain names this pop can support")
-		fs.IntVar(&startArgs.maxPPB, "maxppb", 5, "max price per byte")
+		fs.IntVar(&startArgs.maxPPB, "maxppb", 5, "max price per byte when fetching data")
+		fs.IntVar(&startArgs.ppb, "ppb", 0, "price per byte when serving data")
 		fs.StringVar(&startArgs.indexEndpoint, "index-endpoint", "", "endpoint of a hosted index service")
 		fs.StringVar(&startArgs.upgradeSecret, "upgrade-secret", "", "secret used to verify upgrade message signatures, if provided the server will listen for github webhook request and automatically upgrade the pop")
 		fs.BoolVar(&startArgs.certmagic, "certmagic", false, "run certmagic to get TLS certificates")
@@ -183,6 +185,7 @@ Manage your Myel point of presence from the command line.
 		FilToken:       filToken,
 		PrivKey:        privKey,
 		MaxPPB:         int64(startArgs.maxPPB),
+		ppb:            int64(startArgs.ppb),
 		Regions:        regions,
 		Capacity:       capacity,
 		ReplInterval:   startArgs.replInterval,

--- a/cmd/pop/cli/start.go
+++ b/cmd/pop/cli/start.go
@@ -60,7 +60,7 @@ The 'pop start' command starts a pop daemon service.
 		fs.StringVar(&startArgs.filToken, "fil-token", "", "token to authorize filecoin api access")
 		fs.StringVar(&startArgs.filTokenType, "fil-token-type", "Bearer", "auth token type")
 		fs.StringVar(&startArgs.privKeyPath, "privkey", "", "path to private key to use by default")
-		fs.StringVar(&startArgs.regions, "regions", "", "provider regions separated by commas")
+		fs.StringVar(&startArgs.regions, "regions", "Global", "provider regions separated by commas")
 		fs.StringVar(&startArgs.capacity, "capacity", "100GB", "storage space allocated for the node")
 		fs.DurationVar(&startArgs.replInterval, "replinterval", 0, "at which interval to check for new content from peers. 0 means the feature is deactivated")
 		fs.StringVar(&startArgs.domains, "domains", "", "comma separated list of domain names this pop can support")

--- a/cmd/pop/cli/start.go
+++ b/cmd/pop/cli/start.go
@@ -185,7 +185,7 @@ Manage your Myel point of presence from the command line.
 		FilToken:       filToken,
 		PrivKey:        privKey,
 		MaxPPB:         int64(startArgs.maxPPB),
-		ppb:            int64(startArgs.ppb),
+		PPB:            int64(startArgs.ppb),
 		Regions:        regions,
 		Capacity:       capacity,
 		ReplInterval:   startArgs.replInterval,

--- a/exchange/exchange.go
+++ b/exchange/exchange.go
@@ -71,7 +71,7 @@ func New(ctx context.Context, h host.Host, ds datastore.Batching, opts Options) 
 		idx:  idx,
 		rou:  NewGossipRouting(h, opts.PubSub, opts.GossipTracer, opts.Regions),
 		pay:  payments.New(ctx, opts.FilecoinAPI, opts.Wallet, ds, opts.Blockstore),
-		dmgr: deal.NewManager(opts.Regions[0].PPB),
+		dmgr: deal.NewManager(opts.PPB),
 	}
 
 	exch.rpl, err = NewReplication(h, idx, opts.DataTransfer, exch, opts)
@@ -132,7 +132,7 @@ func (e *Exchange) handleQuery(ctx context.Context, p peer.ID, r Region, q deal.
 		PayloadCID:                 q.PayloadCID,
 		Size:                       uint64(stats.Size),
 		PaymentAddress:             e.opts.Wallet.DefaultAddress(),
-		MinPricePerByte:            r.PPB, // TODO: dynamic pricing
+		MinPricePerByte:            e.opts.PPB, // TODO: dynamic pricing
 		MaxPaymentInterval:         deal.DefaultPaymentInterval,
 		MaxPaymentIntervalIncrease: deal.DefaultPaymentIntervalIncrease,
 	}

--- a/exchange/options.go
+++ b/exchange/options.go
@@ -140,6 +140,12 @@ func (opts Options) fillDefaults(ctx context.Context, h host.Host, ds datastore.
 		opts.Capacity = 10737418240
 	}
 
+	if opts.PPB.Nil() {
+		// Default is 0 PPB
+		opts.PPB = big.NewInt(0)
+	}
+
+
 	return opts, nil
 }
 

--- a/exchange/options.go
+++ b/exchange/options.go
@@ -11,6 +11,7 @@ import (
 	dtfimpl "github.com/filecoin-project/go-data-transfer/impl"
 	dtnet "github.com/filecoin-project/go-data-transfer/network"
 	gstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-graphsync"
@@ -76,6 +77,8 @@ type Options struct {
 	WatchEvictionFunc func(DataRef)
 	// WatchAdditionFunc is an optional callback notifying when content is added to the index.
 	WatchAdditionFunc func(DataRef)
+	// PPB is the price per byte the exchange sets when offering a deal.
+	PPB big.Int
 }
 
 // Everything isn't thoroughly validated so we trust users who provide options know what they're doing

--- a/exchange/regions.go
+++ b/exchange/regions.go
@@ -4,8 +4,6 @@ import (
 	"math"
 	"path"
 
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/big"
 )
 
 // Regions: This is very experimental and needs more iterations to be stable
@@ -39,9 +37,6 @@ type Region struct {
 	Name string
 	// Code is a compressed identifier for the region.
 	Code RegionCode
-	// PPB is the minimum price per byte in FIL defined for this region. This does not account for
-	// any dynamic pricing mechanisms.
-	PPB abi.TokenAmount
 	// Bootstrap is a list of peers that can be dialed to find other peers in that region
 	Bootstrap []string
 }
@@ -50,25 +45,21 @@ var (
 	asia = Region{
 		Name:      "Asia",
 		Code:      AsiaRegion,
-		PPB:       abi.NewTokenAmount(1),
 		Bootstrap: []string{},
 	}
 	africa = Region{
 		Name:      "Africa",
 		Code:      AfricaRegion,
-		PPB:       abi.NewTokenAmount(1),
 		Bootstrap: []string{},
 	}
 	southAmerica = Region{
 		Name:      "SouthAmerica",
 		Code:      SouthAmericaRegion,
-		PPB:       abi.NewTokenAmount(1),
 		Bootstrap: []string{},
 	}
 	northAmerica = Region{
 		Name: "NorthAmerica",
 		Code: NorthAmericaRegion,
-		PPB:  abi.NewTokenAmount(1),
 		Bootstrap: []string{
 			"/dns4/ohio.myel.zone/tcp/41504/p2p/12D3KooWStJfAywQmfaVFQDQYr9riDnEFG3VJ3qDGcTidvc4nQtc",
 		},
@@ -76,7 +67,6 @@ var (
 	europe = Region{
 		Name: "Europe",
 		Code: EuropeRegion,
-		PPB:  abi.NewTokenAmount(1),
 		Bootstrap: []string{
 			"/dns4/frankfurt.myel.zone/tcp/41504/p2p/12D3KooWLaJQ7L6Q3VWxNNxqE8Tcj2wAq1QAvdBieSteAxg9KTCr",
 		},
@@ -84,14 +74,15 @@ var (
 	oceania = Region{
 		Name:      "Oceania",
 		Code:      OceaniaRegion,
-		PPB:       abi.NewTokenAmount(1),
 		Bootstrap: []string{},
 	}
 	global = Region{
 		Name:      "Global",
 		Code:      GlobalRegion,
-		PPB:       big.Zero(),
-		Bootstrap: []string{},
+		Bootstrap: []string{
+			"/dns4/frankfurt.myel.zone/tcp/41504/p2p/12D3KooWLaJQ7L6Q3VWxNNxqE8Tcj2wAq1QAvdBieSteAxg9KTCr",
+			"/dns4/ohio.myel.zone/tcp/41504/p2p/12D3KooWStJfAywQmfaVFQDQYr9riDnEFG3VJ3qDGcTidvc4nQtc",
+		},
 	}
 )
 
@@ -131,7 +122,6 @@ func RegionFromTopic(topic string) Region {
 		return Region{
 			Name: name,
 			Code: CustomRegion,
-			PPB:  big.Zero(), // TODO: handle pricing for custom region
 		}
 	}
 	return r

--- a/node/popn.go
+++ b/node/popn.go
@@ -121,7 +121,7 @@ type Options struct {
 	// MaxPPB is the maximum price per byte when fetching data
 	MaxPPB int64
 	// PBB is the price per byte when serving data
-	PPB big.Int
+	PPB int64
 	// Regions is a list of regions a provider chooses to support.
 	// Nothing prevents providers from participating in regions outside of their geographic location however they may get less deals since the latency is likely to be higher
 	Regions []string
@@ -260,7 +260,7 @@ func New(ctx context.Context, opts Options) (*Pop, error) {
 		// every time new content is added/deleted we notify the remote routing service
 		WatchEvictionFunc: nd.onDeleteRef,
 		WatchAdditionFunc: nd.onSetRef,
-		PPB: opts.PPB,
+		PPB: big.NewInt(opts.PPB),
 	}
 	if opts.FilToken != "" {
 		eopts.FilecoinRPCHeader = http.Header{
@@ -309,8 +309,11 @@ func New(ctx context.Context, opts Options) (*Pop, error) {
 		fmt.Printf("==> Loaded default FIL address: %s\n", nd.exch.Wallet().DefaultAddress())
 	}
 
-	// set Max Price Per Byte
-	fmt.Printf("==> Set default Max Price Per Byte (MaxPPB) at %d attoFIL\n", nd.opts.MaxPPB)
+	// set Max Price Per Byte for retrieval
+	fmt.Printf("==> Set default retrieval Max Price Per Byte (MaxPPB) at %d attoFIL\n", nd.opts.MaxPPB)
+
+	// set Price Per Byte for delivery
+	fmt.Printf("==> Set default Price Per Byte (PPB) at %d attoFIL\n", nd.opts.PPB)
 
 	nd.cancelFunc = opts.CancelFunc
 

--- a/node/popn.go
+++ b/node/popn.go
@@ -309,8 +309,8 @@ func New(ctx context.Context, opts Options) (*Pop, error) {
 		fmt.Printf("==> Loaded default FIL address: %s\n", nd.exch.Wallet().DefaultAddress())
 	}
 
-	// set Max Price Per Byte for retrieval
-	fmt.Printf("==> Set default retrieval Max Price Per Byte (MaxPPB) at %d attoFIL\n", nd.opts.MaxPPB)
+	// set Max Price Per Byte for client
+	fmt.Printf("==> Set default client Max Price Per Byte (MaxPPB) at %d attoFIL\n", nd.opts.MaxPPB)
 
 	// set Price Per Byte for delivery
 	fmt.Printf("==> Set default provider Price Per Byte (PPB) at %d attoFIL\n", nd.opts.PPB)

--- a/node/popn.go
+++ b/node/popn.go
@@ -313,7 +313,7 @@ func New(ctx context.Context, opts Options) (*Pop, error) {
 	fmt.Printf("==> Set default retrieval Max Price Per Byte (MaxPPB) at %d attoFIL\n", nd.opts.MaxPPB)
 
 	// set Price Per Byte for delivery
-	fmt.Printf("==> Set default Price Per Byte (PPB) at %d attoFIL\n", nd.opts.PPB)
+	fmt.Printf("==> Set default provider Price Per Byte (PPB) at %d attoFIL\n", nd.opts.PPB)
 
 	nd.cancelFunc = opts.CancelFunc
 

--- a/node/popn.go
+++ b/node/popn.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-cid"
@@ -117,8 +118,10 @@ type Options struct {
 	FilToken string
 	// PrivKey is a hex encoded private key to use for default address
 	PrivKey string
-	// MaxPPB is the maximum price per byte
+	// MaxPPB is the maximum price per byte when fetching data
 	MaxPPB int64
+	// PBB is the price per byte when serving data
+	PPB big.Int
 	// Regions is a list of regions a provider chooses to support.
 	// Nothing prevents providers from participating in regions outside of their geographic location however they may get less deals since the latency is likely to be higher
 	Regions []string
@@ -257,6 +260,7 @@ func New(ctx context.Context, opts Options) (*Pop, error) {
 		// every time new content is added/deleted we notify the remote routing service
 		WatchEvictionFunc: nd.onDeleteRef,
 		WatchAdditionFunc: nd.onSetRef,
+		PPB: opts.PPB,
 	}
 	if opts.FilToken != "" {
 		eopts.FilecoinRPCHeader = http.Header{


### PR DESCRIPTION
- remove region-based PPB defaults
- set PPB for delivery via flag
- `Global` region uses EU and USA bootstraps 
- `Global` is now default region 